### PR TITLE
Only abort Accept loop on EINVAL

### DIFF
--- a/server.go
+++ b/server.go
@@ -223,6 +223,7 @@ func (s *Server) Start(laddr string) error {
 	logger.Infof("Listening on %s", laddr)
 
 	go func() {
+		defer socket.Close()
 		for {
 			conn, err := socket.Accept()
 


### PR DESCRIPTION
The accept method call on the socket can return many different errors but you should only really abort if an `EINVAL` is returned.

I also added a defer to ensure that the socket is closed when the accept loop returns. 
