### PR TITLE
Adds Travis-CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+
+notifications:
+  email: false
+
+install:
+  - make deps
+
+default:
+  - make test
+
+go:
+  - 1.3
+  - 1.4
+  - tip

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ all: $(BINARY)
 $(BINARY): **/*.go *.go
 	go build .
 
+deps:
+	go get .
+
 build: $(BINARY)
 
 clean:


### PR DESCRIPTION
This commit adds [Travis-CI testing](https://travis-ci.org/), which allows
free and easy continuous integration for pull requests
and new commits. It also adds a `make deps` target
in the Makefile for easily adding the dependencies.

It can be enabled [here](http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in).
Just follow instructions 1-2, three is already done. Thanks.
