### PR TITLE
Upgrade to go 1.4, since travis.yml says so

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.3.3
+FROM golang:1.4
 MAINTAINER Alvin Lai <al@alvinlai.com>
 
 RUN apt-get update


### PR DESCRIPTION
Updated `alvin/ssh-chat` docker repo to use go 1.4 too.

Running and working nicely on my server:

```
ssh resnip.com -p 2222
```
