### PR TITLE
Fixed memory leak.

### DIFF
--- a/client.go
+++ b/client.go
@@ -160,6 +160,7 @@ func (c *Client) handleShell(channel ssh.Channel) {
 	go func() {
 		// Block until done, then remove.
 		c.Conn.Wait()
+		close(c.Msg)
 		c.Server.Remove(c)
 	}()
 


### PR DESCRIPTION
c.Msg was never getting closed on client exit. This should fix issue #48 

I used pprof to find it, should it be permanently enabled? The only problem is that an http server must be running in the background. Should I add a command line arg that turns it on?
