### PR TITLE
Highlight only when beep is enabled

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,7 +22,7 @@ const (
    /exit                - Exit the chat.
    /help                - Show this help text.
    /list                - List the users that are currently connected.
-   /beep                - Enable BEL notifications on mention.
+   /alert               - Enable mentions notification.
    /me $ACTION          - Show yourself doing an action.
    /nick $NAME          - Rename yourself to a new name.
    /whois $NAME         - Display information about another connected user.
@@ -217,7 +217,7 @@ func (c *Client) handleShell(channel ssh.Channel) {
 				c.WriteLines(strings.Split(AboutText, "\n"))
 			case "/uptime":
 				c.Write(c.Server.Uptime())
-			case "/beep":
+			case "/alert", "/beep":
 				c.beepMe = !c.beepMe
 				if c.beepMe {
 					c.SysMsg("I'll beep you good.")

--- a/server.go
+++ b/server.go
@@ -105,12 +105,10 @@ func (s *Server) Broadcast(msg string, except *Client) {
 			continue
 		}
 
-		if strings.Contains(msg, client.Name) {
+		if client.beepMe && strings.Contains(msg, client.Name) {
 			// Turn message red if client's name is mentioned, and send BEL if they have enabled beeping
 			personalMsg := strings.Replace(msg, client.Name, highlightFormat+client.Name+Reset, -1)
-			if client.beepMe {
-				personalMsg += beep
-			}
+			personalMsg += beep
 			client.Send(personalMsg)
 		} else {
 			client.Send(msg)


### PR DESCRIPTION
This lets users turn off highlighting, which can be annoying if you have
a one-letter name or something. :/

Also considering enabling beep by default unless you have a short name (<=3 chars?).

Not sure if either of these are a good idea, thoughts?