### PR TITLE
Allow non-PublicKey authentication

### DIFF
--- a/server.go
+++ b/server.go
@@ -77,6 +77,9 @@ func NewServer(privateKey []byte) (*Server, error) {
 			perm := &ssh.Permissions{Extensions: map[string]string{"fingerprint": fingerprint}}
 			return perm, nil
 		},
+		KeyboardInteractiveCallback: func(conn ssh.ConnMetadata, challenge ssh.KeyboardInteractiveChallenge) (*ssh.Permissions, error) {
+			return nil, nil
+		},
 	}
 	config.AddHostKey(signer)
 


### PR DESCRIPTION
This PR is an attempt to address Issue #30.

This PR adds `KeyboardInteractiveCallback` to server config. The SSH client would attempt PublicKey authentication if available, otherwise try other method. `KeyboardInteractiveCallback` serves as a fallback solution in this case. Unlike simply setting `NoClientAuth` to true which disables authentication completely, hence prevent the server from getting user name, a dummy `KeyboardInteractiveCallback` still reads in the user name.

A drawback of this is that, it pretty much renders the Blacklist/Whitelist filtering useless, since an attacker can always disable PublicKey authentication and utilize the interactive authentication. However, on the other hand, even without this, and attacker could keep generating new Public Keys. It would be more expensive but still feasible.

What do you all think if we remove Blacklist/Whitelist from `PublicKeyCallback`, and use a different method (e.g. IP based, rate limits, etc.) for filtering?

The `PublicKeyCallback` seems appropriate for authenticating privileged users (e.g. admins) though.
