### PR TITLE
Adding a quiet mode to ignore system messages.

### DIFF
--- a/server.go
+++ b/server.go
@@ -128,6 +128,10 @@ func (s *Server) Broadcast(msg string, except *Client) {
 			}
 			client.Send(personalMsg)
 		} else {
+			if client.quietMode && strings.HasPrefix(msg, systemMessageFormat) {
+				continue
+			}
+
 			client.Send(msg)
 		}
 	}


### PR DESCRIPTION
# Overview

With many people joining, leaving, renaming, etc, it would be nice to hide some of these messages so that you can focus on the conversation.

This PR adds a "quiet mode" which ignores these extra messages.

## Implementation

I essentially added an if block with a check to see if the string has a `systemMessageFormat` prefix.

Ideally, a message would be more than a plain string and have a type associated so that filtering can be done easier, but  `¯\_(ツ)_/¯`

## Screenshots:

### Quiet mode on (your perspective)
![image](http://i.imgur.com/wigFBxE.png)

#### Other things still display
![image](http://i.imgur.com/eRcL5a5.png)

### What is actually happening
![image](http://i.imgur.com/iAmYfOg.png?1)

