### PR TITLE
Adding passphrase prompt and CLI flag.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -17,6 +17,15 @@ type Auth struct {
 	sync.RWMutex
 }
 
+// NewAuth creates a new default Auth.
+func NewAuth() Auth {
+	return Auth{
+		whitelist: make(map[string]struct{}),
+		banned:    make(map[string]struct{}),
+		ops:       make(map[string]struct{}),
+	}
+}
+
 // AllowAnonymous determines if anonymous users are permitted.
 func (a Auth) AllowAnonymous() bool {
 	a.RLock()


### PR DESCRIPTION
# Overview

My SSH key is passphrase protected. As such, you can't simply read it and feed the byte string to `ssh.ParsePrivateKey`. You first have to unlock it with your passphrase.

This feature implements the ability to accept a passphrase (either on command line or from STDIN), decrypts the key, and then passes it along unencrypted to `ssh.ParsePrivateKey`.

Tested with RSA, and DSA with and without passphrases. My version of OpenSSH wasn't built with EC support so I can't test ECDSA.