### PR TITLE
Display possibly truncated nickname when processing /nick commands.

### DIFF
--- a/server.go
+++ b/server.go
@@ -242,7 +242,7 @@ func (s *Server) Rename(client *Client, newName string) {
 		s.clients[strings.ToLower(client.Name)] = client
 		s.Unlock()
 	}
-	s.SysMsg("%s is now known as %s.", ColorString(client.Color, oldName), ColorString(client.Color, newName))
+	s.SysMsg("%s is now known as %s.", ColorString(client.Color, oldName), ColorString(client.Color, client.Name))
 }
 
 // List lists the clients with the given prefix


### PR DESCRIPTION
Example:

```$ ssh localhost
 * mcroydon joined. (Total connected: 1)
[mcroydon] /nick REALLYLONGNAMETHATISGOINGTOGETTRUNCATED
 * mcroydon is now known as REALLYLONGNAMETHATISGOINGTOGETTR.
```