### PR TITLE
Default port to 2022, updating documentation to match new default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Usage:
 Application Options:
   -v, --verbose    Show verbose logging.
   -i, --identity=  Private key to identify server with. (~/.ssh/id_rsa)
-      --bind=      Host and port to listen on. (0.0.0.0:22)
+      --bind=      Host and port to listen on. (0.0.0.0:2022)
       --admin=     Fingerprint of pubkey to mark as admin.
       --whitelist= Optional file of pubkey fingerprints that are allowed to connect
       --motd=      Message of the Day file (optional)
@@ -40,7 +40,7 @@ After doing `go get github.com/shazow/ssh-chat` on this repo, you should be able
 to run a command like:
 
 ```
-$ ssh-chat --verbose --bind ":2022" --identity ~/.ssh/id_dsa
+$ ssh-chat --verbose --bind ":22" --identity ~/.ssh/id_dsa
 ```
 
 To bind on port 22, you'll need to make sure it's free (move any other ssh

--- a/cmd.go
+++ b/cmd.go
@@ -27,7 +27,7 @@ import _ "net/http/pprof"
 type Options struct {
 	Verbose   []bool   `short:"v" long:"verbose" description:"Show verbose logging."`
 	Identity  string   `short:"i" long:"identity" description:"Private key to identify server with." default:"~/.ssh/id_rsa"`
-	Bind      string   `long:"bind" description:"Host and port to listen on." default:"0.0.0.0:22"`
+	Bind      string   `long:"bind" description:"Host and port to listen on." default:"0.0.0.0:2022"`
 	Admin     []string `long:"admin" description:"Fingerprint of pubkey to mark as admin."`
 	Whitelist string   `long:"whitelist" description:"Optional file of pubkey fingerprints who are allowed to connect."`
 	Motd      string   `long:"motd" description:"Optional Message of the Day file."`
@@ -105,6 +105,8 @@ func main() {
 		os.Exit(4)
 	}
 	defer s.Close()
+
+	fmt.Printf("Listening for connections on %v\n", options.Bind)
 
 	host := NewHost(s)
 	host.auth = &auth

--- a/sshd/doc.go
+++ b/sshd/doc.go
@@ -7,7 +7,7 @@ package sshd
 	config := MakeNoAuth()
 	config.AddHostKey(signer)
 
-	s, err := ListenSSH("0.0.0.0:22", config)
+	s, err := ListenSSH("0.0.0.0:2022", config)
 	if err != nil {
 		// Handle opening socket error
 	}


### PR DESCRIPTION
I also printed port information upon startup, which is what I think #76 was looking for, but this can be moved in to info-level logging if we don't want to see it all the time. Here's an example of the new startup output:

```
$ ./ssh-chat
Listening for connections on 0.0.0.0:2022
```

Open to painting that bikeshed differently.