### PR TITLE
Add `/ignore`/`/unignore` commands

### DIFF
--- a/chat/room.go
+++ b/chat/room.go
@@ -97,6 +97,12 @@ func (r *Room) HandleMsg(m message.Message) {
 		r.history.Add(m)
 		r.Members.Each(func(u identified) {
 			user := u.(*Member).User
+
+			if fromMsg != nil && user.IsIgnoring(fromMsg.From().Id()) {
+				// Skip because ignored
+				return
+			}
+
 			if skip && skipUser == user {
 				// Skip
 				return

--- a/chat/room.go
+++ b/chat/room.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/shazow/ssh-chat/chat/message"
+	"github.com/shazow/ssh-chat/common"
 )
 
 const historyLen = 20
@@ -34,8 +35,8 @@ type Room struct {
 	closed    bool
 	closeOnce sync.Once
 
-	Members *idSet
-	Ops     *idSet
+	Members *common.IdSet
+	Ops     *common.IdSet
 }
 
 // NewRoom creates a new room.
@@ -47,8 +48,8 @@ func NewRoom() *Room {
 		history:   message.NewHistory(historyLen),
 		commands:  *defaultCommands,
 
-		Members: newIdSet(),
-		Ops:     newIdSet(),
+		Members: common.NewIdSet(),
+		Ops:     common.NewIdSet(),
 	}
 }
 
@@ -61,7 +62,7 @@ func (r *Room) SetCommands(commands Commands) {
 func (r *Room) Close() {
 	r.closeOnce.Do(func() {
 		r.closed = true
-		r.Members.Each(func(m identified) {
+		r.Members.Each(func(m common.Identified) {
 			m.(*Member).Close()
 		})
 		r.Members.Clear()
@@ -95,10 +96,10 @@ func (r *Room) HandleMsg(m message.Message) {
 		}
 
 		r.history.Add(m)
-		r.Members.Each(func(u identified) {
+		r.Members.Each(func(u common.Identified) {
 			user := u.(*Member).User
 
-			if fromMsg != nil && user.IsIgnoring(fromMsg.From().Id()) {
+			if fromMsg != nil && user.Ignored.In(fromMsg.From()) {
 				// Skip because ignored
 				return
 			}

--- a/chat/room_test.go
+++ b/chat/room_test.go
@@ -1,8 +1,11 @@
 package chat
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/shazow/ssh-chat/chat/message"
 )
@@ -38,6 +41,134 @@ func TestRoomServe(t *testing.T) {
 	if actual != expected {
 		t.Errorf("Got: %q; Expected: %q", actual, expected)
 	}
+}
+
+type ScreenedUser struct {
+	user   *message.User
+	screen *MockScreen
+}
+
+func TestIgnore(t *testing.T) {
+	var buffer []byte
+
+	ch := NewRoom()
+	go ch.Serve()
+	defer ch.Close()
+
+	// Create 3 users, join the room and clear their screen buffers
+	users := make([]ScreenedUser, 3)
+	for i := 0; i < 3; i++ {
+		screen := &MockScreen{}
+		user := message.NewUserScreen(message.SimpleId(fmt.Sprintf("user%d", i)), screen)
+		users[i] = ScreenedUser{
+			user:   user,
+			screen: screen,
+		}
+
+		_, err := ch.Join(user)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, u := range users {
+		for i := 0; i < 3; i++ {
+			u.user.HandleMsg(u.user.ConsumeOne())
+			u.screen.Read(&buffer)
+		}
+	}
+
+	// Use some handy variable names for distinguish between roles
+	ignorer := users[0]
+	ignored := users[1]
+	other := users[2]
+
+	// test ignoring unexisting user
+	if err := sendCommand("/ignore test", ignorer, ch, &buffer); err != nil {
+		t.Fatal(err)
+	}
+	expectOutput(t, buffer, "-> Err: user test not found."+message.Newline)
+
+	// test ignoring existing user
+	if err := sendCommand("/ignore "+ignored.user.Name(), ignorer, ch, &buffer); err != nil {
+		t.Fatal(err)
+	}
+	expectOutput(t, buffer, "-> "+ignored.user.Name()+" is now being ignored."+message.Newline)
+
+	// ignoring the same user twice returns an error message and doesn't add the user twice
+	if err := sendCommand("/ignore "+ignored.user.Name(), ignorer, ch, &buffer); err != nil {
+		t.Fatal(err)
+	}
+	expectOutput(t, buffer, "-> Err: user already ignored."+message.Newline)
+	if names := ignorer.user.IgnoredNames(); len(names) != 1 {
+		t.Fatalf("should have %d ignored users, has %d", 1, len(names))
+	}
+
+	// when a message is sent from the ignored user, it is delivered to non-ignoring users
+	ch.Send(message.NewPublicMsg("hello", ignored.user))
+	other.user.HandleMsg(other.user.ConsumeOne())
+	other.screen.Read(&buffer)
+	expectOutput(t, buffer, ignored.user.Name()+": hello"+message.Newline)
+
+	// ensure ignorer doesn't have received any message
+	if ignorer.user.HasMessages() {
+		t.Fatal("should not have messages")
+	}
+
+	// `/ignore` returns a list of ignored users
+	if err := sendCommand("/ignore", ignorer, ch, &buffer); err != nil {
+		t.Fatal(err)
+	}
+	expectOutput(t, buffer, "-> 1 ignored: "+ignored.user.Name()+message.Newline)
+
+	// `/unignore [USER]` removes the user from ignored ones
+	if err := sendCommand("/unignore "+ignored.user.Name(), users[0], ch, &buffer); err != nil {
+		t.Fatal(err)
+	}
+	expectOutput(t, buffer, "-> "+ignored.user.Name()+" is not ignored anymore."+message.Newline)
+
+	if err := sendCommand("/ignore", users[0], ch, &buffer); err != nil {
+		t.Fatal(err)
+	}
+	expectOutput(t, buffer, "-> 0 users ignored."+message.Newline)
+
+	if names := ignorer.user.IgnoredNames(); len(names) != 0 {
+		t.Fatalf("should have %d ignored users, has %d", 0, len(names))
+	}
+
+	// after unignoring a user, its messages can be received again
+	ch.Send(message.NewPublicMsg("hello again!", ignored.user))
+
+	// give some time for the channel to get the message
+	time.Sleep(50)
+
+	// ensure ignorer has received the message
+	if !ignorer.user.HasMessages() {
+		t.Fatal("should have messages")
+	}
+	ignorer.user.HandleMsg(ignorer.user.ConsumeOne())
+	ignorer.screen.Read(&buffer)
+	expectOutput(t, buffer, ignored.user.Name()+": hello again!"+message.Newline)
+}
+
+func expectOutput(t *testing.T, buffer []byte, expected string) {
+	bytes := []byte(expected)
+	if !reflect.DeepEqual(buffer, bytes) {
+		t.Errorf("Got: %q; Expected: %q", buffer, expected)
+	}
+}
+
+func sendCommand(cmd string, mock ScreenedUser, room *Room, buffer *[]byte) error {
+	msg, ok := message.NewPublicMsg(cmd, mock.user).ParseCommand()
+	if !ok {
+		return errors.New("cannot parse command message")
+	}
+
+	room.Send(msg)
+	mock.user.HandleMsg(mock.user.ConsumeOne())
+	mock.screen.Read(buffer)
+
+	return nil
 }
 
 func TestRoomJoin(t *testing.T) {

--- a/chat/room_test.go
+++ b/chat/room_test.go
@@ -100,8 +100,8 @@ func TestIgnore(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectOutput(t, buffer, "-> Err: user already ignored."+message.Newline)
-	if names := ignorer.user.IgnoredNames(); len(names) != 1 {
-		t.Fatalf("should have %d ignored users, has %d", 1, len(names))
+	if ignoredList := ignorer.user.Ignored.ListPrefix(""); len(ignoredList) != 1 {
+		t.Fatalf("should have %d ignored users, has %d", 1, len(ignoredList))
 	}
 
 	// when a message is sent from the ignored user, it is delivered to non-ignoring users
@@ -132,15 +132,15 @@ func TestIgnore(t *testing.T) {
 	}
 	expectOutput(t, buffer, "-> 0 users ignored."+message.Newline)
 
-	if names := ignorer.user.IgnoredNames(); len(names) != 0 {
-		t.Fatalf("should have %d ignored users, has %d", 0, len(names))
+	if ignoredList := ignorer.user.Ignored.ListPrefix(""); len(ignoredList) != 0 {
+		t.Fatalf("should have %d ignored users, has %d", 0, len(ignoredList))
 	}
 
 	// after unignoring a user, its messages can be received again
 	ch.Send(message.NewPublicMsg("hello again!", ignored.user))
 
 	// give some time for the channel to get the message
-	time.Sleep(50)
+	time.Sleep(100)
 
 	// ensure ignorer has received the message
 	if !ignorer.user.HasMessages() {

--- a/chat/set_test.go
+++ b/chat/set_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	"github.com/shazow/ssh-chat/chat/message"
+	"github.com/shazow/ssh-chat/common"
 )
 
 func TestSet(t *testing.T) {
 	var err error
-	s := newIdSet()
+	s := common.NewIdSet()
 	u := message.NewUser(message.SimpleId("foo"))
 
 	if s.In(u) {
@@ -31,7 +32,7 @@ func TestSet(t *testing.T) {
 	}
 
 	err = s.Add(u2)
-	if err != ErrIdTaken {
+	if err != common.ErrIdTaken {
 		t.Error(err)
 	}
 

--- a/common/set.go
+++ b/common/set.go
@@ -1,4 +1,4 @@
-package chat
+package common
 
 import (
 	"errors"
@@ -10,45 +10,45 @@ import (
 var ErrIdTaken = errors.New("id already taken")
 
 // The error returned when a requested item does not exist in the set.
-var ErridentifiedMissing = errors.New("item does not exist")
+var ErrIdentifiedMissing = errors.New("item does not exist")
 
 // Interface for an item storeable in the set
-type identified interface {
+type Identified interface {
 	Id() string
 }
 
 // Set with string lookup.
 // TODO: Add trie for efficient prefix lookup?
-type idSet struct {
+type IdSet struct {
 	sync.RWMutex
-	lookup map[string]identified
+	lookup map[string]Identified
 }
 
 // newIdSet creates a new set.
-func newIdSet() *idSet {
-	return &idSet{
-		lookup: map[string]identified{},
+func NewIdSet() *IdSet {
+	return &IdSet{
+		lookup: map[string]Identified{},
 	}
 }
 
 // Clear removes all items and returns the number removed.
-func (s *idSet) Clear() int {
+func (s *IdSet) Clear() int {
 	s.Lock()
 	n := len(s.lookup)
-	s.lookup = map[string]identified{}
+	s.lookup = map[string]Identified{}
 	s.Unlock()
 	return n
 }
 
 // Len returns the size of the set right now.
-func (s *idSet) Len() int {
+func (s *IdSet) Len() int {
 	s.RLock()
 	defer s.RUnlock()
 	return len(s.lookup)
 }
 
 // In checks if an item exists in this set.
-func (s *idSet) In(item identified) bool {
+func (s *IdSet) In(item Identified) bool {
 	s.RLock()
 	_, ok := s.lookup[item.Id()]
 	s.RUnlock()
@@ -56,20 +56,20 @@ func (s *idSet) In(item identified) bool {
 }
 
 // Get returns an item with the given Id.
-func (s *idSet) Get(id string) (identified, error) {
+func (s *IdSet) Get(id string) (Identified, error) {
 	s.RLock()
 	item, ok := s.lookup[id]
 	s.RUnlock()
 
 	if !ok {
-		return nil, ErridentifiedMissing
+		return nil, ErrIdentifiedMissing
 	}
 
 	return item, nil
 }
 
 // Add item to this set if it does not exist already.
-func (s *idSet) Add(item identified) error {
+func (s *IdSet) Add(item Identified) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -83,21 +83,21 @@ func (s *idSet) Add(item identified) error {
 }
 
 // Remove item from this set.
-func (s *idSet) Remove(item identified) error {
+func (s *IdSet) Remove(item Identified) error {
 	s.Lock()
 	defer s.Unlock()
 	id := item.Id()
 	_, found := s.lookup[id]
 	if !found {
-		return ErridentifiedMissing
+		return ErrIdentifiedMissing
 	}
 	delete(s.lookup, id)
 	return nil
 }
 
-// Replace item from old id with new identified.
-// Used for moving the same identified to a new Id, such as a rename.
-func (s *idSet) Replace(oldId string, item identified) error {
+// Replace item from old id with new Identified.
+// Used for moving the same Identified to a new Id, such as a rename.
+func (s *IdSet) Replace(oldId string, item Identified) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -110,11 +110,11 @@ func (s *idSet) Replace(oldId string, item identified) error {
 	// Remove oldId
 	_, found = s.lookup[oldId]
 	if !found {
-		return ErridentifiedMissing
+		return ErrIdentifiedMissing
 	}
 	delete(s.lookup, oldId)
 
-	// Add new identified
+	// Add new Identified
 	s.lookup[item.Id()] = item
 
 	return nil
@@ -122,7 +122,7 @@ func (s *idSet) Replace(oldId string, item identified) error {
 
 // Each loops over every item while holding a read lock and applies fn to each
 // element.
-func (s *idSet) Each(fn func(item identified)) {
+func (s *IdSet) Each(fn func(item Identified)) {
 	s.RLock()
 	for _, item := range s.lookup {
 		fn(item)
@@ -131,8 +131,8 @@ func (s *idSet) Each(fn func(item identified)) {
 }
 
 // ListPrefix returns a list of items with a prefix, case insensitive.
-func (s *idSet) ListPrefix(prefix string) []identified {
-	r := []identified{}
+func (s *IdSet) ListPrefix(prefix string) []Identified {
+	r := []Identified{}
 	prefix = strings.ToLower(prefix)
 
 	s.RLock()


### PR DESCRIPTION
Added the ability to ignore other users.

`/ignore [USER]` ignores messages from the provided user. Calling `/ignore` without parameters will display the list of currently ignored users.

`/unignore USER` will remove the ignored user from the ignored list, so to receive its messages again.

Upon reconnecting the ignored messages are displayed normally, but this should be the desired behavior.