### PR TITLE
Create /setmotd command; use /motd to display it

### DIFF
--- a/host.go
+++ b/host.go
@@ -422,7 +422,7 @@ func (h *Host) InitCommands(c *chat.Commands) {
 
 	c.Add(chat.Command{
 		Op:         true,
-		Prefix:     "/motd",
+		Prefix:     "/setmotd",
 		PrefixHelp: "MESSAGE",
 		Help:       "Set the MESSAGE of the day.",
 		Handler: func(room *chat.Room, msg message.CommandMsg) error {
@@ -442,6 +442,17 @@ func (h *Host) InitCommands(c *chat.Commands) {
 			if motd != "" {
 				room.Send(message.NewAnnounceMsg(motd))
 			}
+
+			return nil
+		},
+	})
+	
+	c.Add(chat.Command{
+		Prefix:     "/motd",
+		Help:       "Display the MESSAGE of the day.",
+		Handler: func(room *chat.Room, msg message.CommandMsg) error {
+
+			room.Send(message.NewAnnounceMsg(h.motd))
 
 			return nil
 		},


### PR DESCRIPTION
/motd displays the motd instead of changing it, so that a (non op) user can see it without having to rejoin.
Motd can be set by op with /setmotd