### PR TITLE
Fixing zero division error for one color themes

### DIFF
--- a/chat/message/theme.go
+++ b/chat/message/theme.go
@@ -83,6 +83,9 @@ type Palette struct {
 
 // Get a color by index, overflows are looped around.
 func (p Palette) Get(i int) Style {
+	if p.size == 1 {
+		return p.colors[0]
+	}
 	return p.colors[i%(p.size-1)]
 }
 


### PR DESCRIPTION
This fixes a zero division error for themes with only one color.