### PR TITLE
Themes: Adding Solarized Dark and Mono Green (hacker)

### DIFF
--- a/chat/message/theme.go
+++ b/chat/message/theme.go
@@ -173,8 +173,35 @@ func readableColors256() *Palette {
 	return &p
 }
 
+// A theme that users Solarized theme accents
+func solarizedColors() *Palette {
+	size := 9
+	p := Palette{
+		colors: make([]Style, size),
+		size:   size,
+	}
+	nums := [9]int{1, 2, 3, 4, 5, 6, 7, 9, 13}
+	for x := 0; x < 9; x++ {
+		p.colors[x] = Color256(nums[x])
+	}
+	return &p
+}
+
+// Hacker green colors (only uses one color)
+func hackerColors() *Palette {
+	size := 1
+	p := Palette{
+		colors: make([]Style, size),
+		size:   size,
+	}
+	p.colors[0] = Color256(82)
+	return &p
+}
+
 func init() {
 	palette := readableColors256()
+	solar   := solarizedColors()
+	hacker  := hackerColors()
 
 	Themes = []Theme{
 		{
@@ -183,6 +210,20 @@ func init() {
 			sys:       palette.Get(8),                             // Grey
 			pm:        palette.Get(7),                             // White
 			highlight: style(Bold + "\033[48;5;11m\033[38;5;16m"), // Yellow highlight
+		},
+		{
+			id:        "solarized",
+			names:     solar,
+			sys:       Color256(11),
+			pm:        Color256(15),
+			highlight: style(Bold + "\033[48;5;202m\033[38;5;256m"), // orange highlight
+		},
+		{
+			id:        "hacker",
+			names:     hacker,
+			sys:       Color256(22),
+			pm:        Color256(22),
+			highlight: style(Bold + "\033[48;5;22m\033[38;5;256m"), // green bg black fg
 		},
 		{
 			id: "mono",


### PR DESCRIPTION
Similar to #190, except now this uses a solarized dark theme using their accents for user names. System messages should be visible now on solarized dark terminals (discussed in #160).

Here's a sample using solarized dark on Terminator.
![2016-08-08-001836_262x150_scrot](https://cloud.githubusercontent.com/assets/15330989/17469199/aba714c4-5cfd-11e6-9c17-b12d8d27fcb5.png)

Hacker green theme is the same as #190.
