### PR TITLE
command.go: modifying Theme command to show all available themes

### DIFF
--- a/chat/command.go
+++ b/chat/command.go
@@ -3,6 +3,7 @@ package chat
 // FIXME: Would be sweet if we could piggyback on a cli parser or something.
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -180,7 +181,7 @@ func InitCommands(c *Commands) {
 	c.Add(Command{
 		Prefix:     "/theme",
 		PrefixHelp: "[colors|...]",
-		Help:       "Set your color theme. (More themes: solarized, mono, hacker)",
+		Help:       "Set your color theme.",
 		Handler: func(room *Room, msg message.CommandMsg) error {
 			user := msg.From()
 			args := msg.Args()
@@ -190,8 +191,16 @@ func InitCommands(c *Commands) {
 				if cfg.Theme != nil {
 					theme = cfg.Theme.ID()
 				}
-				body := fmt.Sprintf("Current theme: %s", theme)
-				room.Send(message.NewSystemMsg(body, user))
+				var output bytes.Buffer
+				fmt.Fprintf(&output, "Current theme: %s%s", theme, message.Newline)
+				fmt.Fprintf(&output, "   Themes available: ")
+				for i, t := range message.Themes {
+					fmt.Fprintf(&output, t.ID())
+					if i < len(message.Themes)-1 {
+						fmt.Fprintf(&output, ", ")
+					}
+				}
+				room.Send(message.NewSystemMsg(output.String(), user))
 				return nil
 			}
 


### PR DESCRIPTION
Shows all themes on an empty `/theme` call. Not a very friendly way to join all the strings since all the Theme names are locked behind `theme.ID()`. It's either do each ID call in each cycle of the loop and add it to a string, or build a list of all the Theme names, then use String.Join to merge them all together and use that. (Third option: have a list of all theme strings somewhere to avoid having to do iteration/list building every time someone calls `/theme`?)