### PR TITLE
Adding global timestamp option to messages.

### DIFF
--- a/chat/message/message.go
+++ b/chat/message/message.go
@@ -108,7 +108,9 @@ func (m PublicMsg) Render(t *Theme) string {
 	if t == nil {
 		return m.String()
 	}
-
+	if (m.From().GetTimeStampVisible()) {
+		return fmt.Sprintf("[%s] %s: %s", time.Now().Format("15:04:05"), t.ColorName(m.from), m.body)
+	}
 	return fmt.Sprintf("%s: %s", t.ColorName(m.from), m.body)
 }
 
@@ -125,10 +127,16 @@ func (m PublicMsg) RenderFor(cfg UserConfig) string {
 	if cfg.Bell {
 		body += Bel
 	}
+	if (m.From().GetTimeStampVisible()) {
+		return fmt.Sprintf("[%s] %s: %s", time.Now().Format("15:04:05"), cfg.Theme.ColorName(m.from), m.body)
+	}
 	return fmt.Sprintf("%s: %s", cfg.Theme.ColorName(m.from), body)
 }
 
 func (m PublicMsg) String() string {
+	if (m.From().GetTimeStampVisible()) {
+		return fmt.Sprintf("[%s] %s: %s", time.Now().Format("15:04:05"), m.from.Name(), m.body)
+	}
 	return fmt.Sprintf("%s: %s", m.from.Name(), m.body)
 }
 
@@ -151,6 +159,9 @@ func NewEmoteMsg(body string, from *User) *EmoteMsg {
 }
 
 func (m EmoteMsg) Render(t *Theme) string {
+	if (m.from.GetTimeStampVisible()) {
+		return fmt.Sprintf("[%s] ** %s %s", time.Now().Format("15:04:05"), m.from.Name(), m.body)
+	}
 	return fmt.Sprintf("** %s %s", m.from.Name(), m.body)
 }
 
@@ -177,6 +188,9 @@ func (m PrivateMsg) To() *User {
 
 func (m PrivateMsg) Render(t *Theme) string {
 	s := fmt.Sprintf("[PM from %s] %s", m.from.Name(), m.body)
+	if (m.from.GetTimeStampVisible()) {
+		s = fmt.Sprintf("[%s][PM from %s] %s", time.Now().Format("15:04:05"), m.from.Name(), m.body)
+	}
 	if t == nil {
 		return s
 	}

--- a/chat/message/user.go
+++ b/chat/message/user.go
@@ -33,6 +33,7 @@ type User struct {
 	mu      sync.Mutex
 	config  UserConfig
 	replyTo *User // Set when user gets a /msg, for replying.
+	TimeStamp bool
 }
 
 func NewUser(identity Identifier) *User {
@@ -43,6 +44,7 @@ func NewUser(identity Identifier) *User {
 		msg:        make(chan Message, messageBuffer),
 		done:       make(chan struct{}),
 		Ignored:    set.New(),
+		TimeStamp:  false,
 	}
 	u.setColorIdx(rand.Int())
 
@@ -72,6 +74,20 @@ func (u *User) SetConfig(cfg UserConfig) {
 func (u *User) SetID(id string) {
 	u.Identifier.SetID(id)
 	u.setColorIdx(rand.Int())
+}
+
+// Sets visiblity of timestamp.
+func (u *User) SetTimeStampVisible(TSvis bool) {
+	u.mu.Lock()
+	defer u.mu.Unlock()	
+	u.TimeStamp = TSvis
+}
+
+// Gets visibility status of timestamp.
+func (u *User) GetTimeStampVisible() bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.TimeStamp
 }
 
 // ReplyTo returns the last user that messaged this user.

--- a/cmd/ssh-chat/cmd.go
+++ b/cmd/ssh-chat/cmd.go
@@ -36,6 +36,7 @@ type Options struct {
 	Motd      string `long:"motd" description:"Optional Message of the Day file."`
 	Log       string `long:"log" description:"Write chat log to this file."`
 	Pprof     int    `long:"pprof" description:"Enable pprof http server for profiling."`
+	TStamps   bool   `long:"timestamps" description:"Enable"`
 }
 
 var logLevels = []log.Level{
@@ -122,6 +123,7 @@ func main() {
 	host := sshchat.NewHost(s, auth)
 	host.SetTheme(message.Themes[0])
 	host.Version = Version
+	host.SetTimeStamp(options.TStamps)
 
 	err = fromFile(options.Admin, func(line []byte) error {
 		key, _, _, _, err := ssh.ParseAuthorizedKey(line)


### PR DESCRIPTION
This is a feature that I needed - Quite simply when the server is started with the --timestamp flag, all messages including user prompts will have a timestamps added.