### PR TITLE
Colorize /name output with selected theme

### DIFF
--- a/chat/command.go
+++ b/chat/command.go
@@ -173,10 +173,16 @@ func InitCommands(c *Commands) {
 		Prefix: "/names",
 		Help:   "List users who are connected.",
 		Handler: func(room *Room, msg message.CommandMsg) error {
+			theme := msg.From().Config().Theme
+			if theme == nil || theme.ID() == "mono" {
+				names := room.NamesPrefix("")
+				body := fmt.Sprintf("%d connected: %s", len(names), strings.Join(names, ", "))
+				room.Send(message.NewSystemMsg(body, msg.From()))
+				return nil
+			}
+
 			names := room.Members.ListPrefix("")
 			colNames := make([]string, len(names))
-			theme := msg.From().Config().Theme
-
 			for i, uname := range names {
 				colNames[i] = theme.ColorName(uname.Value().(*Member).User)
 			}

--- a/chat/command.go
+++ b/chat/command.go
@@ -174,17 +174,21 @@ func InitCommands(c *Commands) {
 		Help:   "List users who are connected.",
 		Handler: func(room *Room, msg message.CommandMsg) error {
 			theme := msg.From().Config().Theme
-			if theme == nil || theme.ID() == "mono" {
-				names := room.NamesPrefix("")
-				body := fmt.Sprintf("%d connected: %s", len(names), strings.Join(names, ", "))
-				room.Send(message.NewSystemMsg(body, msg.From()))
-				return nil
+
+			colorize := func(u *message.User) string {
+				return theme.ColorName(u)
+			}
+
+			if theme == nil {
+				colorize = func(u *message.User) string {
+					return u.Name()
+				}
 			}
 
 			names := room.Members.ListPrefix("")
 			colNames := make([]string, len(names))
 			for i, uname := range names {
-				colNames[i] = theme.ColorName(uname.Value().(*Member).User)
+				colNames[i] = colorize(uname.Value().(*Member).User)
 			}
 
 			body := fmt.Sprintf("%d connected: %s", len(colNames), strings.Join(colNames, ", "))

--- a/chat/command.go
+++ b/chat/command.go
@@ -173,9 +173,15 @@ func InitCommands(c *Commands) {
 		Prefix: "/names",
 		Help:   "List users who are connected.",
 		Handler: func(room *Room, msg message.CommandMsg) error {
-			// TODO: colorize
-			names := room.NamesPrefix("")
-			body := fmt.Sprintf("%d connected: %s", len(names), strings.Join(names, ", "))
+			names := room.Members.ListPrefix("")
+			colNames := make([]string, len(names))
+			theme := msg.From().Config().Theme
+
+			for i, uname := range names {
+				colNames[i] = theme.ColorName(uname.Value().(*Member).User)
+			}
+
+			body := fmt.Sprintf("%d connected: %s", len(colNames), strings.Join(colNames, ", "))
 			room.Send(message.NewSystemMsg(body, msg.From()))
 			return nil
 		},


### PR DESCRIPTION
In reference to #205.

`/names` output is now colored with the user's current theme. The upside is that it makes `/names` more appealing. The downside is clients that don't support ANSI escape codes might see a lot of garbage output instead of simple names. I'm not sure how to work around that issue itself.

How `/names` looks with the available themes:
![colornames_example](https://user-images.githubusercontent.com/15330989/31179406-e97a7f6e-a8e9-11e7-90cb-5f407fbdb698.png)

I can add a check that skips the coloring if the selected theme is mono. That way a user can at least avoid getting garbage output from `/names` when they have no ANSI support.
