### PR TITLE
Adapted my repo to shazow. Changes...

### DIFF
--- a/chat/message/identity.go
+++ b/chat/message/identity.go
@@ -5,6 +5,8 @@ type Identifier interface {
 	ID() string
 	SetID(string)
 	Name() string
+	Chat() string
+	SetChat(string)
 }
 
 // SimpleID is a simple Identifier implementation used for testing.
@@ -23,4 +25,13 @@ func (i SimpleID) SetID(s string) {
 // Name returns the ID
 func (i SimpleID) Name() string {
 	return i.ID()
+}
+
+// Chat returns the chat name
+func (i SimpleID) Chat() string {
+	return i.Chat()
+}
+
+func (i SimpleID) SetChat(s string) {
+
 }

--- a/chat/message/message.go
+++ b/chat/message/message.go
@@ -88,7 +88,7 @@ func (m PublicMsg) From() *User {
 
 func (m PublicMsg) ParseCommand() (*CommandMsg, bool) {
 	// Check if the message is a command
-	if !strings.HasPrefix(m.body, "/") {
+	if !strings.HasPrefix(m.body, "/") && !strings.HasPrefix(m.body, ":") {
 		return nil, false
 	}
 

--- a/chat/room.go
+++ b/chat/room.go
@@ -10,8 +10,8 @@ import (
 	"github.com/shazow/ssh-chat/set"
 )
 
-const historyLen = 20
-const roomBuffer = 10
+const historyLen = 5
+const roomBuffer = 250
 
 // The error returned when a message is sent to a room that is already
 // closed.
@@ -37,6 +37,7 @@ type Room struct {
 
 	Members *set.Set
 	Ops     *set.Set
+	Masters *set.Set
 }
 
 // NewRoom creates a new room.
@@ -50,6 +51,7 @@ func NewRoom() *Room {
 
 		Members: set.New(),
 		Ops:     set.New(),
+		Masters: set.New(),
 	}
 }
 
@@ -165,6 +167,7 @@ func (r *Room) Leave(u message.Identifier) error {
 		return err
 	}
 	r.Ops.Remove(u.ID())
+	r.Masters.Remove(u.ID())
 	s := fmt.Sprintf("%s left.", u.Name())
 	r.Send(message.NewAnnounceMsg(s))
 	return nil
@@ -210,6 +213,11 @@ func (r *Room) MemberByID(id string) (*Member, bool) {
 // IsOp returns whether a user is an operator in this room.
 func (r *Room) IsOp(u *message.User) bool {
 	return r.Ops.In(u.ID())
+}
+
+// IsMaster returns whether a user is an admin master in this room.
+func (r *Room) IsMaster(u *message.User) bool {
+	return r.Masters.In(u.ID())
 }
 
 // Topic of the room.

--- a/identity.go
+++ b/identity.go
@@ -14,6 +14,7 @@ import (
 type Identity struct {
 	sshd.Connection
 	id      string
+	chat    string
 	created time.Time
 }
 
@@ -42,8 +43,22 @@ func (i Identity) Name() string {
 	return i.id
 }
 
+func (i Identity) Chat() string {
+	return i.chat
+}
+
+func (i *Identity) SetChat(c string) {
+	i.chat = c
+}
+
 // Whois returns a whois description for non-admin users.
 func (i Identity) Whois() string {
+	return "name: " + i.Name() + message.Newline +
+		" > joined: " + humanize.Time(i.created)
+}
+
+// WhoisAdmin returns a whois description for admin users.
+func (i Identity) WhoisAdmin() string {
 	fingerprint := "(no public key)"
 	if i.PublicKey() != nil {
 		fingerprint = sshd.Fingerprint(i.PublicKey())
@@ -54,8 +69,7 @@ func (i Identity) Whois() string {
 		" > joined: " + humanize.Time(i.created)
 }
 
-// WhoisAdmin returns a whois description for admin users.
-func (i Identity) WhoisAdmin() string {
+func (i Identity) WhoisMaster() string {
 	ip, _, _ := net.SplitHostPort(i.RemoteAddr().String())
 	fingerprint := "(no public key)"
 	if i.PublicKey() != nil {


### PR DESCRIPTION
- Added new rank: Administators (or masters). This rank can add or delete operators, but cannot add or remove another administrators. Administrators rank is designed by public key on server startup.
- Added "vim mode". With this mode you can use commands as ':' instead of '/'. As you can see in the code, the Prefix parameter of Command structure was changed by a neutral parameter for future introductions of prefixes.
- New Help function. This function add help for admin rank.
- Added the following commands:
  - setnick: Administrators can change the nick of another user.
  - private: Users can stablish privates conversations. This conversations are permanent until they execute endprivate command.
  - endprivate: Finish private conversation.
  - welcome: Prints motd. Only admins can execute this.
  - whois: In whois only admins can see ip.
  - delop: Allow admins to delete an operator (or moderator as is mentioned in some parts of the code).
- Changed historyLen and roomBuffer vars.
- In cmd tool have been added fsnotify to update public key files (admin and moderator public key files). This is to prevent to restart the server everytime we want to add an administrator.
- Added new prompt mode. In this mode you can see in which room you are talking. As default is 'general'. If you start private conversation the room will be the name of the another user. This part has been introduced for future implementations.
- As I said before now exists private conversations (unlike msg command).