### PR TITLE
cmd: Code cleanup

### DIFF
--- a/cmd/ssh-chat/cmd.go
+++ b/cmd/ssh-chat/cmd.go
@@ -57,7 +57,6 @@ func main() {
 		if p == nil {
 			fmt.Print(err)
 		}
-		os.Exit(1)
 		return
 	}
 
@@ -69,7 +68,7 @@ func main() {
 
 	if options.Version {
 		fmt.Println(Version)
-		os.Exit(0)
+		return
 	}
 
 	// Figure out the log level
@@ -177,7 +176,6 @@ func main() {
 
 	<-sig // Wait for ^C signal
 	fmt.Fprintln(os.Stderr, "Interrupt signal detected, shutting down.")
-	os.Exit(0)
 }
 
 func fromFile(path string, handler func(line []byte) error) error {

--- a/cmd/ssh-chat/cmd.go
+++ b/cmd/ssh-chat/cmd.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/alexcesaro/log"
 	"github.com/alexcesaro/log/golog"
-	"github.com/jessevdk/go-flags"
+	flags "github.com/jessevdk/go-flags"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/shazow/ssh-chat"
+	sshchat "github.com/shazow/ssh-chat"
 	"github.com/shazow/ssh-chat/chat"
 	"github.com/shazow/ssh-chat/chat/message"
 	"github.com/shazow/ssh-chat/sshd"

--- a/logger.go
+++ b/logger.go
@@ -1,7 +1,7 @@
 package sshchat
 
 import (
-	"bytes"
+	"io/ioutil"
 
 	"github.com/alexcesaro/log"
 	"github.com/alexcesaro/log/golog"
@@ -15,6 +15,5 @@ func SetLogger(l *golog.Logger) {
 
 func init() {
 	// Set a default null logger
-	var b bytes.Buffer
-	SetLogger(golog.New(&b, log.Debug))
+	SetLogger(golog.New(ioutil.Discard, log.Debug))
 }


### PR DESCRIPTION
os.Exit does not run defered calls, i changed os.Exit(0) to return because they do the same thing but return will execute defered calls. also clarified imports :)

I could create a slice of global cleanup functions and execute them in fail (like what i did [here](https://github.com/UlisseMini/clean)) but i'm not sure if its really worth it since all you're doing is closing a few files.