### PR TITLE
#315: added missing Close calls on ssh.ServerConn

### DIFF
--- a/sshd/net.go
+++ b/sshd/net.go
@@ -59,7 +59,6 @@ func (l *SSHListener) Serve() {
 			term, err := l.handleConn(conn)
 			if err != nil {
 				logger.Printf("[%s] Failed to handshake: %s", conn.RemoteAddr(), err)
-				conn.Close() // Must be closed to avoid a leak
 				return
 			}
 			l.HandlerFunc(term)

--- a/sshd/terminal.go
+++ b/sshd/terminal.go
@@ -68,10 +68,12 @@ type Terminal struct {
 // Make new terminal from a session channel
 func NewTerminal(conn *ssh.ServerConn, ch ssh.NewChannel) (*Terminal, error) {
 	if ch.ChannelType() != "session" {
+		conn.Close()
 		return nil, ErrNotSessionChannel
 	}
 	channel, requests, err := ch.Accept()
 	if err != nil {
+		conn.Close()
 		return nil, err
 	}
 	term := Terminal{
@@ -119,6 +121,7 @@ func NewSession(conn *ssh.ServerConn, channels <-chan ssh.NewChannel) (*Terminal
 		return NewTerminal(conn, ch)
 	}
 
+	conn.Close()
 	return nil, ErrNoSessionChannel
 }
 


### PR DESCRIPTION
This change does two things

- hands over the ownership of the accepted connections to `handleConn`
- makes the function `NewSession` and `NewTerminal` responsible for closing the connection in case of an error

