### PR TITLE
Command shouldn't look like chat message

### DIFF
--- a/chat/message/message.go
+++ b/chat/message/message.go
@@ -268,3 +268,7 @@ func (m CommandMsg) Args() []string {
 func (m CommandMsg) Body() string {
 	return m.body
 }
+
+func (m CommandMsg) RenderSelf(cfg UserConfig) string {
+	return m.body
+}


### PR DESCRIPTION
For #329 

Rather than looking like

```
[chris] /help
-> Available commands:
```

it looks like
```
/help
-> Available commands:
```

Feel free to hold off or reject this, I just felt like giving it a try.
