### PR TITLE
Apply env vars SSHCHAT_TIMESTAMP and SSHCHAT_THEME

### DIFF
--- a/host.go
+++ b/host.go
@@ -96,6 +96,28 @@ func (h *Host) Connect(term *sshd.Terminal) {
 	cfg := user.Config()
 	cfg.Theme = &h.theme
 	user.SetConfig(cfg)
+
+	env := term.Env()
+	for _, e := range env {
+		switch e.Key {
+		case "SSHCHAT_TIMESTAMP":
+			if e.Value != "" && e.Value != "0" {
+				cmd := "/timestamp"
+				if e.Value != "1" {
+					cmd += " " + e.Value
+				}
+				if msg, ok := message.NewPublicMsg(cmd, user).ParseCommand(); ok {
+					h.Room.HandleMsg(msg)
+				}
+			}
+		case "SSHCHAT_THEME":
+			cmd := "/theme " + e.Value
+			if msg, ok := message.NewPublicMsg(cmd, user).ParseCommand(); ok {
+				h.Room.HandleMsg(msg)
+			}
+		}
+	}
+
 	go user.Consume()
 
 	// Close term once user is closed.

--- a/sshd/pty.go
+++ b/sshd/pty.go
@@ -6,8 +6,8 @@ import "encoding/binary"
 
 // parsePtyRequest parses the payload of the pty-req message and extracts the
 // dimensions of the terminal. See RFC 4254, section 6.2.
-func parsePtyRequest(s []byte) (width, height int, ok bool) {
-	_, s, ok = parseString(s)
+func parsePtyRequest(s []byte) (term string, width, height int, ok bool) {
+	term, s, ok = parseString(s)
 	if !ok {
 		return
 	}

--- a/sshd/terminal.go
+++ b/sshd/terminal.go
@@ -200,7 +200,7 @@ func (t *Terminal) listen(requests <-chan *ssh.Request, ready chan<- struct{}) {
 			}
 		case "env":
 			var v EnvVar
-			if err := ssh.Unmarshal(req.Payload, &v); err != nil {
+			if err := ssh.Unmarshal(req.Payload, &v); err == nil {
 				t.mu.Lock()
 				t.env = append(t.env, v)
 				t.mu.Unlock()

--- a/sshd/terminal.go
+++ b/sshd/terminal.go
@@ -55,6 +55,29 @@ func (c sshConn) Name() string {
 	return c.User()
 }
 
+// EnvVar is an environment variable key-value pair
+type EnvVar struct {
+	Key   string
+	Value string
+}
+
+func (v EnvVar) String() string {
+	return v.Key + "=" + v.Value
+}
+
+// Env is a wrapper type around []EnvVar with some helper methods
+type Env []EnvVar
+
+// Get returns the latest value for a given key, or empty string if not found
+func (e Env) Get(key string) string {
+	for i := len(e) - 1; i >= 0; i-- {
+		if e[i].Key == key {
+			return e[i].Value
+		}
+	}
+	return ""
+}
+
 // Terminal extends ssh/terminal to include a close method
 type Terminal struct {
 	terminal.Terminal
@@ -63,6 +86,9 @@ type Terminal struct {
 
 	done      chan struct{}
 	closeOnce sync.Once
+
+	mu  sync.Mutex
+	env []EnvVar
 }
 
 // Make new terminal from a session channel
@@ -161,10 +187,27 @@ func (t *Terminal) listen(requests <-chan *ssh.Request) {
 				err := t.SetSize(width, height)
 				ok = err == nil
 			}
+		case "env":
+			var v EnvVar
+			if err := ssh.Unmarshal(req.Payload, &v); err != nil {
+				t.mu.Lock()
+				t.env = append(t.env, v)
+				t.mu.Unlock()
+				ok = true
+			}
 		}
 
 		if req.WantReply {
 			req.Reply(ok, nil)
 		}
 	}
+}
+
+// Env returns a list of environment key-values that have been set. They are
+// returned in the order that they have been set, there is no deduplication or
+// other pre-processing applied.
+func (t *Terminal) Env() Env {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return Env(t.env)
 }


### PR DESCRIPTION
See #272

* SSHCHAT_TIMESTAMP can be 0 or 1 to disable or enable, or can be set to the /timestamp format arg.
* SSHCHAT_THEME is set to the theme name.

This also pulls in #309 - which needed a fix.