### PR TITLE
TERM=bot mode

### DIFF
--- a/chat/message/user.go
+++ b/chat/message/user.go
@@ -161,6 +161,9 @@ func (u *User) render(m Message) string {
 	switch m := m.(type) {
 	case PublicMsg:
 		if u == m.From() {
+			if !cfg.Echo {
+				return ""
+			}
 			out += m.RenderSelf(cfg)
 		} else {
 			out += m.RenderFor(cfg)
@@ -226,6 +229,7 @@ type UserConfig struct {
 	Highlight  *regexp.Regexp
 	Bell       bool
 	Quiet      bool
+	Echo       bool // Echo shows your own messages after sending, disabled for bots
 	Timeformat *string
 	Timezone   *time.Location
 	Theme      *Theme
@@ -237,6 +241,7 @@ var DefaultUserConfig UserConfig
 func init() {
 	DefaultUserConfig = UserConfig{
 		Bell:  true,
+		Echo:  true,
 		Quiet: false,
 	}
 

--- a/host.go
+++ b/host.go
@@ -160,9 +160,11 @@ func (h *Host) Connect(term *sshd.Terminal) {
 	}
 
 	// Successfully joined.
-	term.SetPrompt(GetPrompt(user))
-	term.AutoCompleteCallback = h.AutoCompleteFunction(user)
-	user.SetHighlight(user.Name())
+	if !apiMode {
+		term.SetPrompt(GetPrompt(user))
+		term.AutoCompleteCallback = h.AutoCompleteFunction(user)
+		user.SetHighlight(user.Name())
+	}
 
 	// Should the user be op'd on join?
 	if h.isOp(term.Conn) {
@@ -209,6 +211,11 @@ func (h *Host) Connect(term *sshd.Terminal) {
 
 		// FIXME: Any reason to use h.room.Send(m) instead?
 		h.HandleMsg(m)
+
+		if apiMode {
+			// Skip the remaining rendering workarounds
+			continue
+		}
 
 		cmd := m.Command()
 		if cmd == "/nick" || cmd == "/theme" {

--- a/sshd/terminal.go
+++ b/sshd/terminal.go
@@ -103,7 +103,7 @@ func NewTerminal(conn *ssh.ServerConn, ch ssh.NewChannel) (*Terminal, error) {
 		return nil, err
 	}
 	term := Terminal{
-		Terminal: *terminal.NewTerminal(channel, "Connecting..."),
+		Terminal: *terminal.NewTerminal(channel, ""),
 		Conn:     sshConn{conn},
 		Channel:  channel,
 


### PR DESCRIPTION
This is the beginning of the bot and api modes for ssh-chat.

Primarily, it disables our custom re-rendering pipeline (which emits a slew of control characters that are increasingly hard to parse for bots), it also disables the message echo'ing and defaults to the mono theme. Should be a very clean output that is easy to parse.

This should also make testing easier.

Comparing outputs, default: (using `cat -A`)

```
^[[38;05;245m * me joined. (Connected: 1)^[[0m^M^M$
                                                   [^[[38;05;88mme^[[0m] 
```

TERM=bot:

```
 * me joined. (Connected: 1)^M^M$
```