### PR TITLE
main: Add --unsafe-passphrase

### DIFF
--- a/cmd/ssh-chat/cmd.go
+++ b/cmd/ssh-chat/cmd.go
@@ -30,17 +30,30 @@ var Version string = "dev"
 
 // Options contains the flag options
 type Options struct {
-	Verbose    []bool `short:"v" long:"verbose" description:"Show verbose logging."`
-	Version    bool   `long:"version" description:"Print version and exit."`
-	Identity   string `short:"i" long:"identity" description:"Private key to identify server with." default:"~/.ssh/id_rsa"`
-	Bind       string `long:"bind" description:"Host and port to listen on." default:"0.0.0.0:2022"`
-	Admin      string `long:"admin" description:"File of public keys who are admins."`
-	Whitelist  string `long:"whitelist" description:"Optional file of public keys who are allowed to connect."`
-	Passphrase string `long:"unsafe-passphrase" description:"Require an interactive passphrase to connect. Whitelist feature is more secure."`
-	Motd       string `long:"motd" description:"Optional Message of the Day file."`
-	Log        string `long:"log" description:"Write chat log to this file."`
-	Pprof      int    `long:"pprof" description:"Enable pprof http server for profiling."`
+	Verbose   []bool `short:"v" long:"verbose" description:"Show verbose logging."`
+	Version   bool   `long:"version" description:"Print version and exit."`
+	Identity  string `short:"i" long:"identity" description:"Private key to identify server with." default:"~/.ssh/id_rsa"`
+	Bind      string `long:"bind" description:"Host and port to listen on." default:"0.0.0.0:2022"`
+	Admin     string `long:"admin" description:"File of public keys who are admins."`
+	Whitelist string `long:"whitelist" description:"Optional file of public keys who are allowed to connect."`
+	Motd      string `long:"motd" description:"Optional Message of the Day file."`
+	Log       string `long:"log" description:"Write chat log to this file."`
+	Pprof     int    `long:"pprof" description:"Enable pprof http server for profiling."`
+
+	// Hidden flags, because they're discouraged from being used casually.
+	Passphrase string `long:"unsafe-passphrase" description:"Require an interactive passphrase to connect. Whitelist feature is more secure." hidden:"true"`
 }
+
+const extraHelp = `There are hidden options and easter eggs in ssh-chat. The source code is a good
+place to start looking. Some useful links:
+
+* Project Repository:
+  https://github.com/shazow/ssh-chat
+* Project Wiki FAQ:
+  https://github.com/shazow/ssh-chat/wiki/FAQ
+* Command Flags Declaration:
+  https://github.com/shazow/ssh-chat/blob/master/cmd/ssh-chat/cmd.go#L29
+`
 
 var logLevels = []log.Level{
 	log.Warning,
@@ -60,6 +73,9 @@ func main() {
 	if err != nil {
 		if p == nil {
 			fmt.Print(err)
+		}
+		if flagErr, ok := err.(*flags.Error); ok && flagErr.Type == flags.ErrHelp {
+			fmt.Print(extraHelp)
 		}
 		return
 	}

--- a/cmd/ssh-chat/cmd.go
+++ b/cmd/ssh-chat/cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"os/signal"
 	"os/user"
 	"strings"
+	"time"
 
 	"github.com/alexcesaro/log"
 	"github.com/alexcesaro/log/golog"
@@ -19,23 +21,25 @@ import (
 	"github.com/shazow/ssh-chat/chat"
 	"github.com/shazow/ssh-chat/chat/message"
 	"github.com/shazow/ssh-chat/sshd"
+
+	_ "net/http/pprof"
 )
-import _ "net/http/pprof"
 
 // Version of the binary, assigned during build.
 var Version string = "dev"
 
 // Options contains the flag options
 type Options struct {
-	Verbose   []bool `short:"v" long:"verbose" description:"Show verbose logging."`
-	Version   bool   `long:"version" description:"Print version and exit."`
-	Identity  string `short:"i" long:"identity" description:"Private key to identify server with." default:"~/.ssh/id_rsa"`
-	Bind      string `long:"bind" description:"Host and port to listen on." default:"0.0.0.0:2022"`
-	Admin     string `long:"admin" description:"File of public keys who are admins."`
-	Whitelist string `long:"whitelist" description:"Optional file of public keys who are allowed to connect."`
-	Motd      string `long:"motd" description:"Optional Message of the Day file."`
-	Log       string `long:"log" description:"Write chat log to this file."`
-	Pprof     int    `long:"pprof" description:"Enable pprof http server for profiling."`
+	Verbose    []bool `short:"v" long:"verbose" description:"Show verbose logging."`
+	Version    bool   `long:"version" description:"Print version and exit."`
+	Identity   string `short:"i" long:"identity" description:"Private key to identify server with." default:"~/.ssh/id_rsa"`
+	Bind       string `long:"bind" description:"Host and port to listen on." default:"0.0.0.0:2022"`
+	Admin      string `long:"admin" description:"File of public keys who are admins."`
+	Whitelist  string `long:"whitelist" description:"Optional file of public keys who are allowed to connect."`
+	Passphrase string `long:"unsafe-passphrase" description:"Require an interactive passphrase to connect. Whitelist feature is more secure."`
+	Motd       string `long:"motd" description:"Optional Message of the Day file."`
+	Log        string `long:"log" description:"Write chat log to this file."`
+	Pprof      int    `long:"pprof" description:"Enable pprof http server for profiling."`
 }
 
 var logLevels = []log.Level{
@@ -109,6 +113,28 @@ func main() {
 	config := sshd.MakeAuth(auth)
 	config.AddHostKey(signer)
 	config.ServerVersion = "SSH-2.0-Go ssh-chat"
+
+	if options.Passphrase != "" {
+		cb := config.KeyboardInteractiveCallback
+		config.KeyboardInteractiveCallback = func(conn ssh.ConnMetadata, challenge ssh.KeyboardInteractiveChallenge) (*ssh.Permissions, error) {
+			perm, err := cb(conn, challenge)
+			if err != nil {
+				return perm, err
+			}
+			answers, err := challenge("", "", []string{"Passphrase required to connect: "}, []bool{true})
+			if err != nil {
+				return nil, err
+			}
+			if len(answers) == 1 && answers[0] == options.Passphrase {
+				// Success
+				return perm, nil
+			}
+			// It's not gonna do much but may as well throttle brute force attempts a little
+			time.Sleep(2 * time.Second)
+
+			return nil, errors.New("incorrect passphrase")
+		}
+	}
 
 	s, err := sshd.ListenSSH(options.Bind, config)
 	if err != nil {

--- a/sshd/auth.go
+++ b/sshd/auth.go
@@ -19,6 +19,7 @@ type Auth interface {
 }
 
 // MakeAuth makes an ssh.ServerConfig which performs authentication against an Auth implementation.
+// TODO: Switch to using ssh.AuthMethod instead?
 func MakeAuth(auth Auth) *ssh.ServerConfig {
 	config := ssh.ServerConfig{
 		NoClientAuth: false,


### PR DESCRIPTION
Fixes #288

Looks like this:

![image](https://user-images.githubusercontent.com/6292/79373924-07d2e280-7f25-11ea-8736-9c91c2a10757.png)

Updated usage:

```
Usage:
  ssh-chat [OPTIONS]

Application Options:
  -v, --verbose            Show verbose logging.
      --version            Print version and exit.
  -i, --identity=          Private key to identify server with. (default: ~/.ssh/id_rsa)
      --bind=              Host and port to listen on. (default: 0.0.0.0:2022)
      --admin=             File of public keys who are admins.
      --whitelist=         Optional file of public keys who are allowed to connect.
      --motd=              Optional Message of the Day file.
      --log=               Write chat log to this file.
      --pprof=             Enable pprof http server for profiling.

Help Options:
  -h, --help               Show this help message

There are hidden options and easter eggs in ssh-chat. The source code is a good
place to start looking. Some useful links:

* Project Repository:
  https://github.com/shazow/ssh-chat
* Project Wiki FAQ:
  https://github.com/shazow/ssh-chat/wiki/FAQ
* Command Flags Declaration:
  https://github.com/shazow/ssh-chat/blob/master/cmd/ssh-chat/cmd.go#L29
```

A little sad about the length of `--unsafe-passphrase` but I feel it's worth it.

Also kinda wanna make it a hidden option (documented in the wiki), what do people think of that?
