### PR TITLE
Fix ~ Reply to user with symbol returning Err user not found

### DIFF
--- a/host.go
+++ b/host.go
@@ -379,8 +379,7 @@ func (h *Host) InitCommands(c *chat.Commands) {
 				return errors.New("no message to reply to")
 			}
 
-			name := target.Name()
-			_, found := h.GetUser(name)
+			_, found := h.GetUser(target.ID())
 			if !found {
 				return errors.New("user not found")
 			}
@@ -388,7 +387,7 @@ func (h *Host) InitCommands(c *chat.Commands) {
 			m := message.NewPrivateMsg(strings.Join(args, " "), msg.From(), target)
 			room.Send(&m)
 
-			txt := fmt.Sprintf("[Sent PM to %s]", name)
+			txt := fmt.Sprintf("[Sent PM to %s]", target.Name())
 			ms := message.NewSystemMsg(txt, msg.From())
 			room.Send(ms)
 			target.SetReplyTo(msg.From())


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15857322/111027866-6130e380-840c-11eb-8545-07750aa4b5b5.png)

Fixes https://github.com/shazow/ssh-chat/issues/360
You were right @shazow 👍🏽 

I was careful and kept symbol into to sent message notification (`Sent PM to <symbol> <user>`)