### PR TITLE
Add build script for apple silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ release:
 	CGO_ENABLED=0 GOOS=linux GOARCH=386 LDFLAGS='$(LDFLAGS)' ./build_release "github.com/shazow/ssh-chat/cmd/ssh-chat" README.md LICENSE
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 LDFLAGS='$(LDFLAGS)' ./build_release "github.com/shazow/ssh-chat/cmd/ssh-chat" README.md LICENSE
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 LDFLAGS='$(LDFLAGS)' ./build_release "github.com/shazow/ssh-chat/cmd/ssh-chat" README.md LICENSE
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 LDFLAGS='$(LDFLAGS)' ./build_release "github.com/shazow/ssh-chat/cmd/ssh-chat" README.md LICENSE
 	CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 LDFLAGS='$(LDFLAGS)' ./build_release "github.com/shazow/ssh-chat/cmd/ssh-chat" README.md LICENSE
 	CGO_ENABLED=0 GOOS=windows GOARCH=386 LDFLAGS='$(LDFLAGS)' ./build_release "github.com/shazow/ssh-chat/cmd/ssh-chat" README.md LICENSE
 


### PR DESCRIPTION
Build on MacOS M1 chip successfully.
```
Packaged: ssh-chat-darwin_arm64.tgz
CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 LDFLAGS='-X main.Version=v1.11-rc1-6-g3557bf7 -extldflags "-static"' ./build_release "github.com/shazow/ssh-chat/cmd/ssh-chat" README.md LICENSE
Defaulting to BUILDDIR=build
a ssh-chat
a ssh-chat/LICENSE
a ssh-chat/README.md
a ssh-chat/ssh-chat
```