### PR TITLE
Fix SSHCHAT_TIMESTAMP env variables

### DIFF
--- a/host.go
+++ b/host.go
@@ -49,6 +49,8 @@ type Host struct {
 
 	// GetMOTD is used to reload the motd from an external source
 	GetMOTD func() (string, error)
+	// OnUserJoined is used to notify when a user joins a host
+	OnUserJoined func(*message.User)
 }
 
 // NewHost creates a Host on top of an existing listener.
@@ -181,6 +183,10 @@ func (h *Host) Connect(term *sshd.Terminal) {
 	ratelimit := rateio.NewSimpleLimiter(3, time.Second*3)
 
 	logger.Debugf("[%s] Joined: %s", term.Conn.RemoteAddr(), user.Name())
+
+	if h.OnUserJoined != nil {
+		h.OnUserJoined(user)
+	}
 
 	for {
 		line, err := term.ReadLine()

--- a/host.go
+++ b/host.go
@@ -151,13 +151,11 @@ func (h *Host) Connect(term *sshd.Terminal) {
 		switch e.Key {
 		case "SSHCHAT_TIMESTAMP":
 			if e.Value != "" && e.Value != "0" {
-				fmt.Println("got timestamp", e.Value)
 				cmd := "/timestamp"
 				if e.Value != "1" {
 					cmd += " " + e.Value
 				}
 				if msg, ok := message.NewPublicMsg(cmd, user).ParseCommand(); ok {
-					fmt.Println("sending command to server:", cmd)
 					h.Room.HandleMsg(msg)
 				}
 			}


### PR DESCRIPTION
We were trying to set config based on environment variables before the user was registered in the host. This changes fixes it by moves the configuration step.

I liked the feature so i put a test on it.