### PR TITLE
Move password authentication handling into sshd/auth (fixes #394).

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -113,7 +113,7 @@ func (a *Auth) CheckBans(addr net.Addr, key ssh.PublicKey, clientVersion string)
 }
 
 // CheckPubkey determines if a pubkey fingerprint is permitted.
-func (a *Auth) CheckPubkey(key ssh.PublicKey) error {
+func (a *Auth) CheckPublicKey(key ssh.PublicKey) error {
 	authkey := newAuthKey(key)
 	whitelisted := a.whitelist.In(authkey)
 	if a.AllowAnonymous() || whitelisted {

--- a/auth_test.go
+++ b/auth_test.go
@@ -59,3 +59,37 @@ func TestAuthWhitelist(t *testing.T) {
 		t.Error("Failed to restrict not whitelisted:", err)
 	}
 }
+
+func TestAuthPasswords(t *testing.T) {
+	auth := NewAuth()
+
+	if auth.AcceptPassword() {
+		t.Error("Doesn't known it won't accept passwords.")
+	}
+	auth.SetPassword("")
+	if auth.AcceptPassword() {
+		t.Error("Doesn't known it won't accept passwords.")
+	}
+
+	err := auth.CheckPassword("Pa$$w0rd")
+	if err == nil {
+		t.Error("Failed to deny without password:", err)
+	}
+
+	auth.SetPassword("Pa$$w0rd")
+
+	err = auth.CheckPassword("Pa$$w0rd")
+	if err != nil {
+		t.Error("Failed to allow vaild password:", err)
+	}
+
+	err = auth.CheckPassword("something else")
+	if err == nil {
+		t.Error("Failed to restrict wrong password:", err)
+	}
+
+	auth.SetPassword("")
+	if auth.AcceptPassword() {
+		t.Error("Didn't clear password.")
+	}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -28,7 +28,7 @@ func TestAuthWhitelist(t *testing.T) {
 	}
 
 	auth := NewAuth()
-	err = auth.Check(nil, key, "")
+	err = auth.CheckPubkey(key)
 	if err != nil {
 		t.Error("Failed to permit in default state:", err)
 	}
@@ -44,7 +44,7 @@ func TestAuthWhitelist(t *testing.T) {
 		t.Error("Clone key does not match.")
 	}
 
-	err = auth.Check(nil, keyClone, "")
+	err = auth.CheckPubkey(keyClone)
 	if err != nil {
 		t.Error("Failed to permit whitelisted:", err)
 	}
@@ -54,42 +54,42 @@ func TestAuthWhitelist(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = auth.Check(nil, key2, "")
+	err = auth.CheckPubkey(key2)
 	if err == nil {
 		t.Error("Failed to restrict not whitelisted:", err)
 	}
 }
 
-func TestAuthPasswords(t *testing.T) {
+func TestAuthPassphrases(t *testing.T) {
 	auth := NewAuth()
 
-	if auth.AcceptPassword() {
-		t.Error("Doesn't known it won't accept passwords.")
+	if auth.AcceptPassphrase() {
+		t.Error("Doesn't known it won't accept passphrases.")
 	}
-	auth.SetPassword("")
-	if auth.AcceptPassword() {
-		t.Error("Doesn't known it won't accept passwords.")
+	auth.SetPassphrase("")
+	if auth.AcceptPassphrase() {
+		t.Error("Doesn't known it won't accept passphrases.")
 	}
 
-	err := auth.CheckPassword("Pa$$w0rd")
+	err := auth.CheckPassphrase("Pa$$w0rd")
 	if err == nil {
-		t.Error("Failed to deny without password:", err)
+		t.Error("Failed to deny without passphrase:", err)
 	}
 
-	auth.SetPassword("Pa$$w0rd")
+	auth.SetPassphrase("Pa$$w0rd")
 
-	err = auth.CheckPassword("Pa$$w0rd")
+	err = auth.CheckPassphrase("Pa$$w0rd")
 	if err != nil {
-		t.Error("Failed to allow vaild password:", err)
+		t.Error("Failed to allow vaild passphrase:", err)
 	}
 
-	err = auth.CheckPassword("something else")
+	err = auth.CheckPassphrase("something else")
 	if err == nil {
-		t.Error("Failed to restrict wrong password:", err)
+		t.Error("Failed to restrict wrong passphrase:", err)
 	}
 
-	auth.SetPassword("")
-	if auth.AcceptPassword() {
-		t.Error("Didn't clear password.")
+	auth.SetPassphrase("")
+	if auth.AcceptPassphrase() {
+		t.Error("Didn't clear passphrase.")
 	}
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -28,7 +28,7 @@ func TestAuthWhitelist(t *testing.T) {
 	}
 
 	auth := NewAuth()
-	err = auth.CheckPubkey(key)
+	err = auth.CheckPublicKey(key)
 	if err != nil {
 		t.Error("Failed to permit in default state:", err)
 	}
@@ -44,7 +44,7 @@ func TestAuthWhitelist(t *testing.T) {
 		t.Error("Clone key does not match.")
 	}
 
-	err = auth.CheckPubkey(keyClone)
+	err = auth.CheckPublicKey(keyClone)
 	if err != nil {
 		t.Error("Failed to permit whitelisted:", err)
 	}
@@ -54,7 +54,7 @@ func TestAuthWhitelist(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = auth.CheckPubkey(key2)
+	err = auth.CheckPublicKey(key2)
 	if err == nil {
 		t.Error("Failed to restrict not whitelisted:", err)
 	}

--- a/cmd/ssh-chat/cmd.go
+++ b/cmd/ssh-chat/cmd.go
@@ -135,7 +135,7 @@ func main() {
 	host.Version = Version
 
 	if options.Passphrase != "" {
-		auth.SetPassword(options.Passphrase)
+		auth.SetPassphrase(options.Passphrase)
 	}
 
 	err = fromFile(options.Admin, func(line []byte) error {

--- a/sshd/auth.go
+++ b/sshd/auth.go
@@ -5,21 +5,26 @@ import (
 	"encoding/base64"
 	"errors"
 	"net"
+	"time"
 
 	"github.com/shazow/ssh-chat/internal/sanitize"
 	"golang.org/x/crypto/ssh"
 )
 
-// Auth is used to authenticate connections based on public keys.
+// Auth is used to authenticate connections.
 type Auth interface {
 	// Whether to allow connections without a public key.
 	AllowAnonymous() bool
-	// If password authtication is accepted
-	AcceptPassword() bool
-	// Given address and public key and client agent string, returns nil if the connection should be allowed.
-	Check(net.Addr, ssh.PublicKey, string) error
-	// Given a password, returns nil if the connection should be allowed
-	CheckPassword(string) error
+	// If passphrase authentication is accepted
+	AcceptPassphrase() bool
+	// Given address and public key and client agent string, returns nil if the connection is not banned.
+	CheckBans(net.Addr, ssh.PublicKey, string) error
+	// Given a public key, returns nil if the connection should be allowed.
+	CheckPubkey(ssh.PublicKey) error
+	// Given a passphrase, returns nil if the connection should be allowed.
+	CheckPassphrase(string) error
+	// BanAddr bans an IP address for the specified amount of time.
+	BanAddr(net.Addr, time.Duration)
 }
 
 // MakeAuth makes an ssh.ServerConfig which performs authentication against an Auth implementation.
@@ -29,7 +34,11 @@ func MakeAuth(auth Auth) *ssh.ServerConfig {
 		NoClientAuth: false,
 		// Auth-related things should be constant-time to avoid timing attacks.
 		PublicKeyCallback: func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
-			err := auth.Check(conn.RemoteAddr(), key, sanitize.Data(string(conn.ClientVersion()), 64))
+			err := auth.CheckBans(conn.RemoteAddr(), key, sanitize.Data(string(conn.ClientVersion()), 64))
+			if err != nil {
+				return nil, err
+			}
+			err = auth.CheckPubkey(key)
 			if err != nil {
 				return nil, err
 			}
@@ -43,20 +52,26 @@ func MakeAuth(auth Auth) *ssh.ServerConfig {
 		// avoid preventing the client from including a pubkey in the user
 		// identification.
 		KeyboardInteractiveCallback: func(conn ssh.ConnMetadata, challenge ssh.KeyboardInteractiveChallenge) (*ssh.Permissions, error) {
-			var err error
-			if auth.AcceptPassword() {
+			err := auth.CheckBans(conn.RemoteAddr(), nil, sanitize.Data(string(conn.ClientVersion()), 64))
+			if err != nil {
+				return nil, err
+			}
+			if auth.AcceptPassphrase() {
 				var answers []string
 				answers, err = challenge("", "", []string{"Passphrase required to connect: "}, []bool{true})
 				if err == nil {
 					if len(answers) != 1 {
-						err = errors.New("didn't get password")
+						err = errors.New("didn't get passphrase")
 					} else {
-						err = auth.CheckPassword(answers[0])
-						// TODO: some kind of brute force throttling here?
+						err = auth.CheckPassphrase(answers[0])
+						if err != nil {
+							// TODO: make rate-limiting configurable
+							auth.BanAddr(conn.RemoteAddr(), time.Minute * 1)
+						}
 					}
 				}
-			} else {
-				err = auth.Check(conn.RemoteAddr(), nil, sanitize.Data(string(conn.ClientVersion()), 64))
+			} else if !auth.AllowAnonymous(){
+				err = errors.New("public key authentication required")
 			}
 			return nil, err
 		},

--- a/sshd/client_test.go
+++ b/sshd/client_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -15,15 +16,19 @@ type RejectAuth struct{}
 func (a RejectAuth) AllowAnonymous() bool {
 	return false
 }
-func (a RejectAuth) AcceptPassword() bool {
+func (a RejectAuth) AcceptPassphrase() bool {
 	return false
 }
-func (a RejectAuth) Check(net.Addr, ssh.PublicKey, string) error {
+func (a RejectAuth) CheckBans(addr net.Addr, key ssh.PublicKey, clientVersion string) error {
 	return errRejectAuth
 }
-func (a RejectAuth) CheckPassword(string) error {
+func (a RejectAuth) CheckPubkey(ssh.PublicKey) error {
 	return errRejectAuth
 }
+func (a RejectAuth) CheckPassphrase(string) error {
+	return errRejectAuth
+}
+func (a RejectAuth) BanAddr(net.Addr, time.Duration) {}
 
 func TestClientReject(t *testing.T) {
 	signer, err := NewRandomSigner(512)

--- a/sshd/client_test.go
+++ b/sshd/client_test.go
@@ -15,7 +15,13 @@ type RejectAuth struct{}
 func (a RejectAuth) AllowAnonymous() bool {
 	return false
 }
+func (a RejectAuth) AcceptPassword() bool {
+	return false
+}
 func (a RejectAuth) Check(net.Addr, ssh.PublicKey, string) error {
+	return errRejectAuth
+}
+func (a RejectAuth) CheckPassword(string) error {
 	return errRejectAuth
 }
 

--- a/sshd/client_test.go
+++ b/sshd/client_test.go
@@ -22,7 +22,7 @@ func (a RejectAuth) AcceptPassphrase() bool {
 func (a RejectAuth) CheckBans(addr net.Addr, key ssh.PublicKey, clientVersion string) error {
 	return errRejectAuth
 }
-func (a RejectAuth) CheckPubkey(ssh.PublicKey) error {
+func (a RejectAuth) CheckPublicKey(ssh.PublicKey) error {
 	return errRejectAuth
 }
 func (a RejectAuth) CheckPassphrase(string) error {


### PR DESCRIPTION
Password authentication is now completely handled in Auth. The normal
keyboard-interactive handler checks if passwords are supported and asks
for them, removing the need to override the callbacks.

Brute force throttling is removed; I'd like to base it on IP address
banning, which requires changes to the checks.
Specifically, if it's OK, I'd like to move IP and client ban checks to a new ``CheckBans``
which is called from the keyboard-interactive and public-key callbacks.
Then, a failed password could ban the IP for a configurable amount of time.
This does remove "can't be banned" status of people with a password, though.

I'm not sure, but I think timing attacks against the password are fixed:
- The hashing of the real password happens only at startup.
- The hashing of a provided password is something an attacker can do
themselves; It doesn't leak anything about the real password.
- The hash comparison is constant-time.

