### PR TITLE
Show eror when '/back' or '/away' incorrectly.

### DIFF
--- a/chat/command.go
+++ b/chat/command.go
@@ -469,12 +469,13 @@ func InitCommands(c *Commands) {
 			msg.From().SetAway(awayMsg)
 			if awayMsg != "" {
 				room.Send(message.NewEmoteMsg("has gone away: "+awayMsg, msg.From()))
-			} else if !isAway {
-				room.Send(message.NewSystemMsg("Not away. Append a reason message to set away.", msg.From()))
-			} else {
-				room.Send(message.NewEmoteMsg("is back.", msg.From()))
+				return nil
 			}
-			return nil
+			if isAway {
+				room.Send(message.NewEmoteMsg("is back.", msg.From()))
+				return nil
+			}
+			return errors.New("not away. Append a reason message to set away")
 		},
 	})
 
@@ -486,8 +487,9 @@ func InitCommands(c *Commands) {
 			if isAway {
 				msg.From().SetAway("")
 				room.Send(message.NewEmoteMsg("is back.", msg.From()))
+				return nil
 			}
-			return nil
+			return errors.New("must be away to be back")
 		},
 	})
 


### PR DESCRIPTION
When the user is not set as away, using the
`/back` or `/away` command should return error.
The previous behaviour was inconsistent,
`/away` sent a message and `/back` ignored it.
New behaviour is error for both cases.