### PR TITLE
Docker Compose manifest: mount host's keys and few other improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Custom SSH server written in Go. Instead of a shell, you get a chat prompt.
 
 Join the party:
 
-```
+``` console
 $ ssh ssh.chat
 ```
 
@@ -52,7 +52,7 @@ Additionally, `make debug` runs the server with an http `pprof` server. This all
 
 ## Quick Start
 
-```
+``` console
 Usage:
   ssh-chat [OPTIONS]
 
@@ -74,7 +74,7 @@ Help Options:
 After doing `go get github.com/shazow/ssh-chat/...` on this repo, you should be able
 to run a command like:
 
-```
+``` console
 $ ssh-chat --verbose --bind ":22" --identity ~/.ssh/id_dsa
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,13 @@
-version: '3'
+version: '3.2'
 services:
   app:
+    container_name: ssh-chat
     build: .
     ports:
-        - 2022:2022
-    restart: always
+      - 2022:2022
+    restart: unless-stopped
+    volumes:
+      - type: bind
+        source: ~/.ssh/
+        target: /root/.ssh/
+        read_only: true


### PR DESCRIPTION
* Add SSH keys mount (mimicking default non-Docker behaviour).
* Increase manifest version to lowest 3.x supporting bind mounts.
* Change restart policy from `always` to `unless-stopped`.
* Set a container name.
* Fix port indentation to 2 spaces, as done elsewhere.

Also, minor markdown tweaks on readme.