### PR TITLE
Add command to toggle system bell off/pm/all

### DIFF
--- a/chat/command.go
+++ b/chat/command.go
@@ -265,6 +265,26 @@ func InitCommands(c *Commands) {
 	})
 
 	c.Add(Command{
+		Prefix:     "/systembell",
+		Help:       "Toggle system bell for all messages.",
+		Handler: func(room *Room, msg message.CommandMsg) error {
+			u := msg.From()
+			cfg := u.Config()
+			cfg.Systembell = !cfg.Systembell
+			u.SetConfig(cfg)
+
+			var body string
+			if cfg.Systembell {
+				body = "System bell is toggled ON"
+			} else {
+				body = "System bell is toggled OFF"
+			}
+			room.Send(message.NewSystemMsg(body, u))
+			return nil
+		},
+	})
+
+	c.Add(Command{
 		Prefix:     "/slap",
 		PrefixHelp: "NAME",
 		Handler: func(room *Room, msg message.CommandMsg) error {

--- a/chat/command.go
+++ b/chat/command.go
@@ -265,19 +265,48 @@ func InitCommands(c *Commands) {
 	})
 
 	c.Add(Command{
-		Prefix:     "/systembell",
-		Help:       "Toggle system bell for all messages.",
+		Prefix:     "/bell",
+		PrefixHelp: "[off|pm|all]",
+		Help:       "Set system bell off, only for pm, or for all messages",
 		Handler: func(room *Room, msg message.CommandMsg) error {
 			u := msg.From()
 			cfg := u.Config()
-			cfg.Systembell = !cfg.Systembell
+
+			args := msg.Args()
+			mode := ""
+			if len(args) >= 1 {
+				mode = args[0]
+			}
+
+			switch mode {
+			case "":
+				// Toggle 0 and 1
+				if cfg.Bell != 0 {
+					cfg.Bell = 0
+				} else {
+					cfg.Bell = 1
+				}
+			case "off":
+				cfg.Bell = 0
+			case "pm":
+				cfg.Bell = 1
+			case "all":
+				cfg.Bell = 2
+			default:
+				return errors.New("bell value must be one of: off, pm, all")
+			}
+
 			u.SetConfig(cfg)
 
 			var body string
-			if cfg.Systembell {
-				body = "System bell is toggled ON"
+			if cfg.Bell != 0 {
+				if cfg.Bell == 1 {
+					body = "Bell is toggled ON for private messages"
+				} else {
+					body = "Bell is toggled ON for all messages"
+				}
 			} else {
-				body = "System bell is toggled OFF"
+				body = "Bell is toggled OFF"
 			}
 			room.Send(message.NewSystemMsg(body, u))
 			return nil

--- a/chat/message/message.go
+++ b/chat/message/message.go
@@ -123,7 +123,7 @@ func (m PublicMsg) RenderFor(cfg UserConfig) string {
 	}
 
 	body := cfg.Highlight.ReplaceAllString(m.body, cfg.Theme.Highlight("${1}"))
-	if cfg.Bell {
+	if cfg.Bell != 0 {
 		body += Bel
 	}
 	return fmt.Sprintf("%s: %s", cfg.Theme.ColorName(m.from), body)

--- a/chat/message/user.go
+++ b/chat/message/user.go
@@ -215,13 +215,14 @@ func (u *User) render(m Message) string {
 			return ""
 		} else {
 			out += m.RenderFor(cfg)
-			if cfg.Systembell {
+			if cfg.Bell == 2 {
 				out += Bel
 			}
 		}
 	case *PrivateMsg:
 		out += m.Render(cfg.Theme)
-		if cfg.Bell {
+		//if u != m.From() && m.Command() != "reply" && cfg.Bell != 0 {
+		if u != m.From() && cfg.Bell != 0 {
 			out += Bel
 		}
 	case *CommandMsg:
@@ -275,8 +276,7 @@ func (u *User) Send(m Message) error {
 // Container for per-user configurations.
 type UserConfig struct {
 	Highlight  *regexp.Regexp
-	Bell       bool
-	Systembell bool
+	Bell       int
 	Quiet      bool
 	Echo       bool // Echo shows your own messages after sending, disabled for bots
 	Timeformat *string
@@ -289,8 +289,7 @@ var DefaultUserConfig UserConfig
 
 func init() {
 	DefaultUserConfig = UserConfig{
-		Bell:       true,
-		Systembell: false,
+		Bell:       1,
 		Echo:       true,
 		Quiet:      false,
 	}

--- a/chat/message/user.go
+++ b/chat/message/user.go
@@ -215,6 +215,9 @@ func (u *User) render(m Message) string {
 			return ""
 		} else {
 			out += m.RenderFor(cfg)
+			if cfg.Systembell {
+				out += Bel
+			}
 		}
 	case *PrivateMsg:
 		out += m.Render(cfg.Theme)
@@ -273,6 +276,7 @@ func (u *User) Send(m Message) error {
 type UserConfig struct {
 	Highlight  *regexp.Regexp
 	Bell       bool
+	Systembell bool
 	Quiet      bool
 	Echo       bool // Echo shows your own messages after sending, disabled for bots
 	Timeformat *string
@@ -285,9 +289,10 @@ var DefaultUserConfig UserConfig
 
 func init() {
 	DefaultUserConfig = UserConfig{
-		Bell:  true,
-		Echo:  true,
-		Quiet: false,
+		Bell:       true,
+		Systembell: false,
+		Echo:       true,
+		Quiet:      false,
 	}
 
 	// TODO: Seed random?

--- a/host.go
+++ b/host.go
@@ -169,6 +169,16 @@ func (h *Host) Connect(term *sshd.Terminal) {
 			if msg, ok := message.NewPublicMsg(cmd, user).ParseCommand(); ok {
 				h.Room.HandleMsg(msg)
 			}
+		case "SSHCHAT_SYSTEMBELL":
+			if e.Value != "" && e.Value != "0" {
+				cmd := "/systembell"
+				if e.Value != "1" {
+					cmd += " " + e.Value
+				}
+				if msg, ok := message.NewPublicMsg(cmd, user).ParseCommand(); ok {
+					h.Room.HandleMsg(msg)
+				}
+			}
 		}
 	}
 

--- a/host.go
+++ b/host.go
@@ -169,12 +169,10 @@ func (h *Host) Connect(term *sshd.Terminal) {
 			if msg, ok := message.NewPublicMsg(cmd, user).ParseCommand(); ok {
 				h.Room.HandleMsg(msg)
 			}
-		case "SSHCHAT_SYSTEMBELL":
-			if e.Value != "" && e.Value != "0" {
-				cmd := "/systembell"
-				if e.Value != "1" {
-					cmd += " " + e.Value
-				}
+		case "SSHCHAT_BELL":
+			if e.Value != "" && e.Value != "off" {
+				cmd := "/bell"
+				cmd += " " + e.Value
 				if msg, ok := message.NewPublicMsg(cmd, user).ParseCommand(); ok {
 					h.Room.HandleMsg(msg)
 				}


### PR DESCRIPTION
I started using ssh-chat just a day ago and missed this feature, why private messages "/msg" have a bell sound, but I can't turn it off, or why I can't turn it on for ALL messages?

I notice that the code already have a variable "`Bell`" in "`UserConfig`", but it's value was hard-coded, so, what I did was:
1. make command to change "Bell" value (`/bell [off|pm|all]`), so now users can toggle it (default is "`pm`", just like before).
2. add another option to "Bell", only priv msg had a bell sound, so I added an "all" option, now bell can be set to: "off", "pm" or "all".
3. add an environment variable to make it easier to initialize bell value (in my case I have a shell script to connect to ssh-chat, been able to add `-o SetEnv=SSHCHAT_BELL=all` to the script just makes my life easier.

All features are tested and working as expected.