### PR TITLE
Fixing emojis being sent in PMs when no theme is set (#414)

### DIFF
--- a/chat/message/message.go
+++ b/chat/message/message.go
@@ -191,10 +191,11 @@ func (m PrivateMsg) From() *User {
 }
 
 func (m PrivateMsg) Render(t *Theme) string {
-	s := fmt.Sprintf("[PM from %s] %s", m.from.Name(), m.body)
+	format := "[PM from %s] %s"
 	if t == nil {
-		return s
+		return fmt.Sprintf(format, m.from.ID(), m.body) 
 	}
+	s := fmt.Sprintf(format, m.from.Name(), m.body)
 	return t.ColorPM(s)
 }
 


### PR DESCRIPTION
In reference to #414.

When `t == nil`, no theme is selected, and this is the way to indicate that `TERM=bot` is set.

The logic is branched, and `user.ID()` is used in place of `user.Name()`. The text used in `fmt.Sprintf` is separated and could be lifted from the function and used as a constant instead to avoid repeated allocations if desired (if the Go compiler doesn't do that already in the build step).