### PR TITLE
host.go: avoiding motd output if bot mode set

### DIFF
--- a/host.go
+++ b/host.go
@@ -132,7 +132,7 @@ func (h *Host) Connect(term *sshd.Terminal) {
 	h.mu.Unlock()
 
 	// Send MOTD
-	if motd != "" {
+	if motd != "" && !apiMode {
 		user.Send(message.NewAnnounceMsg(motd))
 	}
 


### PR DESCRIPTION
A basic logic change to avoid writing message-of-the-day text to the user if they connect with `TERM=bot` during the initial connection.