### PR TITLE
Key comments as symbols

### DIFF
--- a/host.go
+++ b/host.go
@@ -101,6 +101,9 @@ func (h *Host) isOp(conn sshd.Connection) bool {
 // Connect a specific Terminal to this host and its room.
 func (h *Host) Connect(term *sshd.Terminal) {
 	id := NewIdentity(term.Conn)
+
+	id.SetSymbol(h.auth.comments[sshd.Fingerprint(id.PublicKey())])
+
 	user := message.NewUserScreen(id, term)
 	user.OnChange = func() {
 		term.SetPrompt(GetPrompt(user))

--- a/host.go
+++ b/host.go
@@ -626,7 +626,7 @@ func (h *Host) InitCommands(c *chat.Commands) {
 			member.IsOp = opValue
 
 			id := member.Identifier.(*Identity)
-			h.auth.Op(id.PublicKey(), until)
+			h.auth.Op(id.PublicKey(), "", until)
 
 			var body string
 			if opValue {
@@ -780,7 +780,7 @@ func (h *Host) InitCommands(c *chat.Commands) {
 				if pk == nil {
 					noKeyUsers = append(noKeyUsers, user.Identifier.Name())
 				} else {
-					h.auth.Allowlist(pk, 0)
+					h.auth.Allowlist(pk, "", 0)
 				}
 			}
 			return nil
@@ -876,9 +876,9 @@ func (h *Host) InitCommands(c *chat.Commands) {
 			case "off":
 				h.auth.SetAllowlistMode(false)
 			case "add":
-				replyLines = forPubkeyUser(args[1:], func(pk ssh.PublicKey) { h.auth.Allowlist(pk, 0) })
+				replyLines = forPubkeyUser(args[1:], func(pk ssh.PublicKey) { h.auth.Allowlist(pk, "", 0) })
 			case "remove":
-				replyLines = forPubkeyUser(args[1:], func(pk ssh.PublicKey) { h.auth.Allowlist(pk, 1) })
+				replyLines = forPubkeyUser(args[1:], func(pk ssh.PublicKey) { h.auth.Allowlist(pk, "", 1) })
 			case "import":
 				replyLines, err = allowlistImport(args[1:])
 			case "reload":


### PR DESCRIPTION
After having bookmarked this project a few years ago, I finally took a stab at implementing a feature I wanted to see. After a review of the issues, I see it's a common ask. It fills some of the needs in issues #367 , #265 , #246 ,  and even #74.  

This PR attempts to implement tying of arbitrary chat usernames to a connecting user's ssh keys. This is implemented in a simple, lightweight way by using the "comment" field that follows the ssh public keys on each line of the files already loaded through the --allowlist and --admin options. The comment field is standard in the openssh authorized_keys format, so lines of public keys from existing files can often be used as-is after trivial review from the server admins. 

When a user connects using a key in the admin or allowlist files, any comment on the used key is pre-pended to their nick in chat. This string is not part of the user's nick; it's the "symbol" prefix that is customarily used to indicate users with ops privileges. As a result,  while users can continue to change their nick suffix as usual, their "symbol" prefix can only be changed by admins using the /rename command. This makes the prefix a reliable means of tying the user to a specific key without needing to take away their ability to use or change nicks freely. 

This implementation requires no additional persistent state management, fits in well with existing use patterns for ssh and irc/chat, requires no new command line options, and has minimal impact on existing ssh-chat use patterns.

What do you think?