### PR TITLE
Keynames for Nick reservation

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -109,6 +109,11 @@ func (a *Auth) Keyname(key ssh.PublicKey) string {
 	return name
 }
 
+func (a *Auth) KeynameFingerprint(keyname string) string {
+	fingerprint := a.fingerprintsByKeyname[keyname]
+	return fingerprint
+}
+
 // SetPassphrase enables passphrase authentication with the given passphrase.
 // If an empty passphrase is given, disable passphrase authentication.
 func (a *Auth) SetPassphrase(passphrase string) {

--- a/auth.go
+++ b/auth.go
@@ -67,6 +67,7 @@ type Auth struct {
 
 	settingsMu      sync.RWMutex
 	allowlistMode   bool
+	keynamesMode    bool
 	opLoader        KeyLoader
 	allowlistLoader KeyLoader
 }
@@ -94,6 +95,18 @@ func (a *Auth) SetAllowlistMode(value bool) {
 	a.settingsMu.Lock()
 	defer a.settingsMu.Unlock()
 	a.allowlistMode = value
+}
+
+func (a *Auth) SetKeynamesMode(value bool) {
+	a.settingsMu.Lock()
+	defer a.settingsMu.Unlock()
+	a.keynamesMode = value
+}
+
+func (a *Auth) Keyname(key ssh.PublicKey) string {
+	fingerprint := sshd.Fingerprint(key)
+	name := a.keynamesByFingerprint[fingerprint]
+	return name
 }
 
 // SetPassphrase enables passphrase authentication with the given passphrase.

--- a/chat/command.go
+++ b/chat/command.go
@@ -142,36 +142,6 @@ func InitCommands(c *Commands) {
 	})
 	c.Alias("/exit", "/quit")
 
-	c.Add(Command{
-		Prefix:     "/nick",
-		PrefixHelp: "NAME",
-		Help:       "Rename yourself.",
-		Handler: func(room *Room, msg message.CommandMsg) error {
-			args := msg.Args()
-			if len(args) != 1 {
-				return ErrMissingArg
-			}
-			u := msg.From()
-
-			member, ok := room.MemberByID(u.ID())
-			if !ok {
-				return errors.New("failed to find member")
-			}
-
-			oldID := member.ID()
-			newID := sanitize.Name(args[0])
-			if newID == oldID {
-				return errors.New("new name is the same as the original")
-			}
-			member.SetID(newID)
-			err := room.Rename(oldID, member)
-			if err != nil {
-				member.SetID(oldID)
-				return err
-			}
-			return nil
-		},
-	})
 
 	c.Add(Command{
 		Prefix: "/names",

--- a/cmd/ssh-chat/cmd.go
+++ b/cmd/ssh-chat/cmd.go
@@ -38,6 +38,7 @@ type Options struct {
 	Version    bool     `long:"version" description:"Print version and exit."`
 	Allowlist  string   `long:"allowlist" description:"Optional file of public keys who are allowed to connect."`
 	Whitelist  string   `long:"whitelist" dexcription:"Old name for allowlist option"`
+	Keynames   bool     `long:"keynames" description:"Reserve usernames by appending them (after a space) to their keys in the admin or allowlist files."`
 	Passphrase string   `long:"unsafe-passphrase" description:"Require an interactive passphrase to connect. Allowlist feature is more secure."`
 }
 
@@ -156,6 +157,8 @@ func main() {
 		fail(6, "Failed to load allowlist: %v\n", err)
 	}
 	auth.SetAllowlistMode(options.Allowlist != "")
+
+	auth.SetKeynamesMode(options.Keynames)
 
 	if options.Motd != "" {
 		host.GetMOTD = func() (string, error) {

--- a/host.go
+++ b/host.go
@@ -626,7 +626,7 @@ func (h *Host) InitCommands(c *chat.Commands) {
 			member.IsOp = opValue
 
 			id := member.Identifier.(*Identity)
-			h.auth.Op(id.PublicKey(), until)
+			h.auth.Op(id.PublicKey(), "", until)
 
 			var body string
 			if opValue {
@@ -780,7 +780,7 @@ func (h *Host) InitCommands(c *chat.Commands) {
 				if pk == nil {
 					noKeyUsers = append(noKeyUsers, user.Identifier.Name())
 				} else {
-					h.auth.Allowlist(pk, 0)
+					h.auth.Allowlist(pk, "", 0)
 				}
 			}
 			return nil
@@ -876,9 +876,9 @@ func (h *Host) InitCommands(c *chat.Commands) {
 			case "off":
 				h.auth.SetAllowlistMode(false)
 			case "add":
-				replyLines = forPubkeyUser(args[1:], func(pk ssh.PublicKey) { h.auth.Allowlist(pk, 0) })
+				replyLines = forPubkeyUser(args[1:], func(pk ssh.PublicKey) { h.auth.Allowlist(pk, "", 0) })
 			case "remove":
-				replyLines = forPubkeyUser(args[1:], func(pk ssh.PublicKey) { h.auth.Allowlist(pk, 1) })
+				replyLines = forPubkeyUser(args[1:], func(pk ssh.PublicKey) { h.auth.Allowlist(pk, "", 1) })
 			case "import":
 				replyLines, err = allowlistImport(args[1:])
 			case "reload":

--- a/host.go
+++ b/host.go
@@ -101,6 +101,15 @@ func (h *Host) isOp(conn sshd.Connection) bool {
 // Connect a specific Terminal to this host and its room.
 func (h *Host) Connect(term *sshd.Terminal) {
 	id := NewIdentity(term.Conn)
+
+	if h.auth.keynamesMode {
+		name := h.auth.Keyname(id.PublicKey())
+		if len(name) >0 {
+			id.SetName(name)
+			id.SetSymbol("✓")
+		}
+	}
+
 	user := message.NewUserScreen(id, term)
 	user.OnChange = func() {
 		term.SetPrompt(GetPrompt(user))


### PR DESCRIPTION
This pr supersedes and replaces #420 

So here we have a full-blown chat nick reservation implementation. 

Chat nicks are reserved for users by passing the `--keynames` option to ssh-chat at startup, and placing the desired nickname at the end of the public key line (separated by a space) in the allow list or admin key files. This is the "comment" field is traditionally filled out with `$user@$host` information when OpenSSH generates an ssh keypair. This makes the public key file suitable for simply copying and pasting into the allowlist or admin files, line for line, in order to reserve usernames. Only the first word of the comment field is used for the reserved nick.

When a user with a reserved nick connects, they are automatically assigned the username assigned to their key along with a checkmark symbol prefix to indicate that their key fingerprint is verified by the server. 

The `/nick` and `/rename` commands have been reimplemented to prevent users from receiving reserved nicks unless their ssh key matches that recorded in the reservation lists. 