### PR TITLE
Verify nicks

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -33,7 +33,7 @@ func TestAuthAllowlist(t *testing.T) {
 		t.Error("Failed to permit in default state:", err)
 	}
 
-	auth.Allowlist(key, 0)
+	auth.Allowlist(key, "", 0)
 	auth.SetAllowlistMode(true)
 
 	keyClone, err := ClonePublicKey(key)

--- a/host.go
+++ b/host.go
@@ -626,7 +626,7 @@ func (h *Host) InitCommands(c *chat.Commands) {
 			member.IsOp = opValue
 
 			id := member.Identifier.(*Identity)
-			h.auth.Op(id.PublicKey(), until)
+			h.auth.Op(id.PublicKey(), "", until)
 
 			var body string
 			if opValue {
@@ -780,7 +780,7 @@ func (h *Host) InitCommands(c *chat.Commands) {
 				if pk == nil {
 					noKeyUsers = append(noKeyUsers, user.Identifier.Name())
 				} else {
-					h.auth.Allowlist(pk, 0)
+					h.auth.Allowlist(pk, "", 0)
 				}
 			}
 			return nil
@@ -876,9 +876,9 @@ func (h *Host) InitCommands(c *chat.Commands) {
 			case "off":
 				h.auth.SetAllowlistMode(false)
 			case "add":
-				replyLines = forPubkeyUser(args[1:], func(pk ssh.PublicKey) { h.auth.Allowlist(pk, 0) })
+				replyLines = forPubkeyUser(args[1:], func(pk ssh.PublicKey) { h.auth.Allowlist(pk, "", 0) })
 			case "remove":
-				replyLines = forPubkeyUser(args[1:], func(pk ssh.PublicKey) { h.auth.Allowlist(pk, 1) })
+				replyLines = forPubkeyUser(args[1:], func(pk ssh.PublicKey) { h.auth.Allowlist(pk, "", 1) })
 			case "import":
 				replyLines, err = allowlistImport(args[1:])
 			case "reload":

--- a/host_test.go
+++ b/host_test.go
@@ -164,12 +164,12 @@ func TestHostAllowlist(t *testing.T) {
 	}
 	clientKey := clientPrivateKey.PublicKey()
 	loadCount := -1
-	loader := func() ([]ssh.PublicKey, error) {
+	loader := func() ([]ssh.PublicKey, []string, error) {
 		loadCount++
 		return [][]ssh.PublicKey{
 			{},
 			{clientKey},
-		}[loadCount], nil
+		}[loadCount], []string{}, nil
 	}
 	auth.LoadAllowlist(loader)
 


### PR DESCRIPTION
This pr is an alternative implementation of a feature to reserve chat nicks. It is more conservative, simpler, does fewer things, and makes fewer changes to the code base than previous prs #420 and #423 . Thanks to @shazow for many good points of advice from the previous pr thread.

The first commit only loads ssh key comments onto the Auth object. Key comments are any string (trimmed for spaces) that follow the public key on each line of the admin and allowlist key files. Each comment is associated with the key it appears with. This commit does not attempt to parse the comments or use them in any way; it simply stores them for use in future commits. 

The second commit implements an injectable `checkName()` function on the Room object, which is then used during Join() and Rename() operations to reject attempts by users to make use of a nick that is associated with another key. A nick is parsed from the first word of a key comment, and sanitized. 

That's it. Things that are not in the implementation thus far:
- Reserved nicks are //not// assigned automatically to connecting users; this should significantly reduce user surprise that would accompany such behaviour. 
    - If a user attempts to connect with a nick reserved by another key, they are simply assigned a "guestX" nick, in the same way they would if they previously attempted to connect with a nick that was empty or already in use. 
    - If a user attempts to use `/nick` or `/rename` to set a nick for a user reserved to a different key, the attempt fails with an error. The current implementation cannot distinguish between renaming attempts made by users from those made by admins, so all attempts are rejected. 
- command line options. The nick guard is currently enabled by default. Since user surprise is reduced significantly by the fact that nicks are not assigned automatically upon connection, a command line option to enable the behaviour is less necessary. If a command line option is desired to enable this behavior, it is easy to add. 
- symbol-setting. This, too, is easy to add in the future if desired. The essentials of the nick reservation feature can be considered in isolation from the aesthetics of how to present it to users. 

I also added `go fmt` and test adjustments to this pr. 